### PR TITLE
Support compiling source units (.java files) that generate multiple .class files.

### DIFF
--- a/inline-java.cabal
+++ b/inline-java.cabal
@@ -29,6 +29,7 @@ library
     binary >=0.7,
     bytestring >=0.10,
     containers >=0.5,
+    directory >=1.2,
     distributed-closure >=0.3,
     filepath >= 1,
     ghc-heap-view >= 0.5,
@@ -58,6 +59,7 @@ test-suite spec
   build-depends:
     base,
     bytestring,
+    jni,
     jvm,
     hspec,
     inline-java,

--- a/tests/Language/Java/InlineSpec.hs
+++ b/tests/Language/Java/InlineSpec.hs
@@ -5,6 +5,7 @@
 module Language.Java.InlineSpec where
 
 import Data.Int
+import Foreign.JNI.Types (JObject)
 import Language.Java.Inline
 import Test.Hspec
 
@@ -33,3 +34,10 @@ spec = do
       it "Supports antiquotation variables in blocks" $ do
         let z = 1 :: Int32
         [java| { return $z + 1; } |] `shouldReturn` (2 :: Int32)
+
+      it "Supports anonymous classes" $ do
+        _ :: JObject <- [java| new Object() {} |]
+        return ()
+
+      it "Supports multiple anonymous classes" $ do
+        [java| new Object() {}.equals(new Object() {}) |] `shouldReturn` False


### PR DESCRIPTION
Whenever a class definition has inline anonymous classes, companion
.class files are generated. So we need to embed those in binaries and
load them too. Function literals are syntactic sugar for anonymous
classes.