### PR TITLE
Fix Reflect instance for lists so it uses the right class to create a java array.

### DIFF
--- a/jvm/src/Language/Java.hs
+++ b/jvm/src/Language/Java.hs
@@ -495,9 +495,9 @@ withStatic [d|
   instance Reflect a ty => Reflect [a] ('Array ty) where
     reflect xs = do
       let n = fromIntegral (length xs)
-      klass <- findClass "java/lang/Object"
-      array <- newObjectArray n klass
-      forM_ (zip [0..n-1] xs) $ \(i, x) -> do
+      array <- findClass (referenceTypeName (sing :: Sing ty))
+                 >>= newObjectArray n
+      forM_ (zip [0..n-1] xs) $ \(i, x) ->
         setObjectArrayElement array i =<< reflect x
       return (unsafeCast array)
   |]

--- a/jvm/src/Language/Java.hs
+++ b/jvm/src/Language/Java.hs
@@ -294,13 +294,15 @@ type instance Interp ('Base a) = Interp a
 -- | Extract a concrete Haskell value from the space of Java objects. That is to
 -- say, unmarshall a Java object to a Haskell value. Unlike coercing, in general
 -- reifying induces allocations and copies.
-class (Interp (Uncurry a) ~ ty, SingI ty) => Reify a ty where
+class (Interp (Uncurry a) ~ ty, SingI ty, IsReferenceType ty)
+      => Reify a ty where
   reify :: J ty -> IO a
 
 -- | Inject a concrete Haskell value into the space of Java objects. That is to
 -- say, marshall a Haskell value to a Java object. Unlike coercing, in general
 -- reflection induces allocations and copies.
-class (Interp (Uncurry a) ~ ty, SingI ty) => Reflect a ty where
+class (Interp (Uncurry a) ~ ty, SingI ty, IsReferenceType ty)
+      => Reflect a ty where
   reflect :: a -> IO (J ty)
 
 #if ! __GLASGOW_HASKELL__ == 800
@@ -337,10 +339,10 @@ reflectMVector newfun fill mv = do
 withStatic [d|
   type instance Interp (J ty) = ty
 
-  instance SingI ty => Reify (J ty) ty where
+  instance (SingI ty, IsReferenceType ty) => Reify (J ty) ty where
     reify x = return x
 
-  instance SingI ty => Reflect (J ty) ty where
+  instance (SingI ty, IsReferenceType ty) => Reflect (J ty) ty where
     reflect x = return x
 
   type instance Interp () = 'Class "java.lang.Object"


### PR DESCRIPTION
The problem with the existing instance, say `Reflect [Text] ('Array ('Class "java.lang.String"))` is that it always allocates an `Object[]`, while the upper layers need/expect a `java.lang.String[]`.

There are two things I'm not convinced about in this patch:
1. It doesn't work for generics. Generics have `IsReferenceType` instance with a constraint:
```Haskell
instance IsReferenceType ty => IsReferenceType ('Generic ty tys)
```
AFAIU all generics are reference types. What's the point of asking for the extra constraint to use functions like `referenceTypeName`?.

2. It looks like `Reflect` and `Reify` should have `IsReferenceType` as a superclass constraint. It isn't possible to define them for primitive types, or at least the `J ('Prim symbol)` appearing in the signature of `reflect/reify` would appear to have no java equivalent.

Related to this, the signature of `newObjectArray` is misguiding. It makes one think it returns an `Object[]` when indeed the return type depends on the given klass argument. This wouldn't be an issue if there was a hierarchy of arrays, but `S[]` does not extend `T[]` when `S` extends `T`.