### PR TITLE
Bind the JNINativeMethod data structure and RegisterNatives().

### DIFF
--- a/jni/jni.cabal
+++ b/jni/jni.cabal
@@ -27,6 +27,7 @@ library
   extra-libraries: jvm
   exposed-modules:
     Foreign.JNI
+    Foreign.JNI.NativeMethod
     Foreign.JNI.Types
     Foreign.JNI.String
   build-depends:

--- a/jni/src/Foreign/JNI.hs
+++ b/jni/src/Foreign/JNI.hs
@@ -31,6 +31,7 @@ module Foreign.JNI
     withJVM
     -- ** Class loading
   , defineClass
+  , registerNatives
     -- ** Query functions
   , findClass
   , getFieldID
@@ -119,6 +120,7 @@ import Data.Monoid ((<>))
 import Data.Typeable (Typeable)
 import Data.TLS.PThread
 import Foreign.C (CChar)
+import Foreign.JNI.NativeMethod
 import Foreign.JNI.Types
 import qualified Foreign.JNI.String as JNI
 import Foreign.Marshal.Array
@@ -244,6 +246,20 @@ defineClass name (coerce -> upcast -> loader) buf = withJNIEnv $ \env ->
                                      $(jobject loader),
                                      $bs-ptr:buf,
                                      $bs-len:buf) } |]
+registerNatives
+  :: JClass
+  -> [JNINativeMethod]
+  -> IO ()
+registerNatives cls methods = withJNIEnv $ \env ->
+    throwIfException env $
+    withArray methods $ \cmethods -> do
+      let numMethods = fromIntegral $ length methods
+      _ <- [CU.exp| jint {
+             (*$(JNIEnv *env))->RegisterNatives($(JNIEnv *env),
+                                                $(jclass cls),
+                                                $(JNINativeMethod *cmethods),
+                                                $(int numMethods)) } |]
+      return ()
 
 findClass
   :: JNI.String -- ^ Class name

--- a/jni/src/Foreign/JNI/NativeMethod.hsc
+++ b/jni/src/Foreign/JNI/NativeMethod.hsc
@@ -1,0 +1,40 @@
+-- | Bindings to the JNINativeMethod struct.
+
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Foreign.JNI.NativeMethod where
+
+import qualified Data.ByteString.Unsafe as BS
+import qualified Foreign.JNI.String as JNI
+import Foreign.Ptr (FunPtr)
+import Foreign.Storable (Storable(..))
+
+#include <jni.h>
+
+#if __GLASGOW_HASKELL__ < 800
+#let alignment t = "%lu", (unsigned long)offsetof(struct {char x__; t (y__); }, y__)
+#endif
+
+data JNINativeMethod = forall a. JNINativeMethod
+  { jniNativeMethodName :: JNI.String
+  , jniNativeMethodSignature :: JNI.String
+  , jniNativeMethodFunPtr :: FunPtr a
+  }
+
+instance Storable JNINativeMethod where
+  sizeOf _ = #{size JNINativeMethod}
+  alignment _ = #{alignment JNINativeMethod}
+  peek ptr = do
+      name <- BS.unsafePackCString =<< #{peek JNINativeMethod, name} ptr
+      sig <- BS.unsafePackCString =<< #{peek JNINativeMethod, signature} ptr
+      fptr <- #{peek JNINativeMethod, fnPtr} ptr
+      return $
+        JNINativeMethod
+          (JNI.unsafeFromByteString name)
+          (JNI.unsafeFromByteString sig)
+          fptr
+  poke ptr JNINativeMethod{..} = do
+      JNI.withString jniNativeMethodName $ #{poke JNINativeMethod, name} ptr
+      JNI.withString jniNativeMethodSignature $ #{poke JNINativeMethod, signature} ptr
+      #{poke JNINativeMethod, fnPtr} ptr jniNativeMethodFunPtr

--- a/jni/src/Foreign/JNI/Types.hs
+++ b/jni/src/Foreign/JNI/Types.hs
@@ -77,6 +77,7 @@ import Data.Singletons.TypeLits (KnownSymbol, symbolVal)
 import Data.String (fromString)
 import Data.Word
 import Foreign.C (CChar)
+import Foreign.JNI.NativeMethod
 import qualified Foreign.JNI.String as JNI
 import Foreign.Ptr
 import Foreign.Storable (Storable(..))
@@ -346,6 +347,7 @@ jniCtx = mempty { ctxTypesTable = fromList tytab }
       -- Internal types
       , (TypeName "JavaVM", [t| JVM |])
       , (TypeName "JNIEnv", [t| JNIEnv |])
+      , (TypeName "JNINativeMethod", [t| JNINativeMethod |])
       , (TypeName "jfieldID", [t| JFieldID |])
       , (TypeName "jmethodID", [t| JMethodID |])
       , (TypeName "jsize", [t| Int32 |])


### PR DESCRIPTION
This provides an alternate method of binding C/Haskell code to Java
classes. Binding can happen at runtime, on-the-fly, rather than at
program initialization time.