### PR TITLE
Add the GlobalJ type.

### DIFF
--- a/jvm/jvm.cabal
+++ b/jvm/jvm.cabal
@@ -22,6 +22,7 @@ library
   hs-source-dirs: src
   exposed-modules:
     Language.Java
+    Language.Java.GlobalJ
   build-depends:
     base >= 4.7 && < 5,
     bytestring >=0.10,

--- a/jvm/src/Language/Java.hs
+++ b/jvm/src/Language/Java.hs
@@ -61,7 +61,7 @@ module Language.Java
   , Type(..)
   , Uncurry
   , Interp
-  , sing
+  , SingI(..)
   ) where
 
 import Control.Distributed.Closure

--- a/jvm/src/Language/Java/GlobalJ.hs
+++ b/jvm/src/Language/Java/GlobalJ.hs
@@ -1,0 +1,48 @@
+-- | A type to stand for global references to Java values.
+
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Language.Java.GlobalJ
+  ( GlobalJ
+  , newGlobalJ
+  , withGlobalJ
+  ) where
+
+import Control.Distributed.Closure.TH
+import Control.Monad
+import GHC.ForeignPtr (newConcForeignPtr)
+import Foreign.ForeignPtr (ForeignPtr, withForeignPtr)
+import Foreign.JNI
+import Foreign.JNI.Types
+import Language.Java
+
+-- | Global references to java values.
+--
+-- When storing references in Haskell data types, this type should be preferred
+-- over bare `J ty`. When 'GlobalJ' values are no longer reachable on the
+-- Haskell side, 'deleteGlobalRef' is called.
+newtype GlobalJ ty = GlobalJ (ForeignPtr (J ty))
+
+-- | Creates a new global reference.
+newGlobalJ :: J ty -> IO (GlobalJ ty)
+newGlobalJ = newGlobalRef >=> \gj@(J p) ->
+    GlobalJ <$> newConcForeignPtr p (deleteGlobalRef gj)
+
+-- | Exposes the reference in a 'GlobalJ' value, ensuring that it is not deleted
+-- before the given action completes.
+withGlobalJ :: GlobalJ ty -> (J ty -> IO a) -> IO a
+withGlobalJ (GlobalJ fp) io = withForeignPtr fp (io . J)
+
+withStatic [d|
+  type instance Interp (GlobalJ ty) = ty
+
+  instance (SingI ty, IsReferenceType ty) => Reify (GlobalJ ty) ty where
+    reify = newGlobalJ
+ |]


### PR DESCRIPTION
This type provides references to java values which will be deleted when they are no longer needed on the Haskell side.