### PR TITLE
Switch to latest inline-c release.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "vendor/constraints"]
 	path = vendor/constraints
 	url = https://github.com/mboes/constraints
-[submodule "vendor/inline-c"]
-	path = vendor/inline-c
-	url = https://github.com/mboes/inline-c

--- a/jni/jni.cabal
+++ b/jni/jni.cabal
@@ -36,7 +36,7 @@ library
     bytestring >=0.10,
     choice >= 0.2.0,
     containers >=0.5,
-    inline-c >=0.5,
+    inline-c >=0.5.6.1,
     singletons >= 2.0,
     thread-local-storage >=0.1
   default-language: Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,12 +5,11 @@ packages:
 - jni
 - jvm
 - jvm-streaming
-- location: vendor/inline-c
-  extra-dep: true
 
 extra-deps:
-- thread-local-storage-0.1.0.3
 - choice-0.2.0
+- inline-c-0.5.6.1
+- thread-local-storage-0.1.0.3
 
 skip-ghc-check: true
 


### PR DESCRIPTION
No need to have a vendored submodule anymore.