### PR TITLE
Use Prelude.String's in the Sing (t :: JType) instance.

### DIFF
--- a/jvm/jvm.cabal
+++ b/jvm/jvm.cabal
@@ -56,6 +56,7 @@ benchmark micro-benchmarks
   build-depends:
     base >= 4.8 && < 5,
     criterion,
+    jni,
     jvm
   default-language: Haskell2010
   ghc-options: -threaded

--- a/src/Language/Java/Inline.hs
+++ b/src/Language/Java/Inline.hs
@@ -140,9 +140,9 @@ toJavaType ty = case Java.parser Java.ttype (pretty ty) of
     Right x -> x
   where
     pretty :: Sing (a :: JType) -> String
-    pretty (SClass sym) = JNI.toChars sym
-    pretty (SIface sym) = JNI.toChars sym
-    pretty (SPrim sym) = JNI.toChars sym
+    pretty (SClass sym) = sym
+    pretty (SIface sym) = sym
+    pretty (SPrim sym) = sym
     pretty (SArray ty1) = pretty ty1 ++ "[]"
     pretty (SGeneric _ty1 _tys) = error "toJavaType(Generic): Unimplemented."
     pretty SVoid = "void"


### PR DESCRIPTION
The singleton instance used JNI.String, which is a wrapper over ByteStrings, relies on unsafePerformIO and related functions to do comparisons. For some reason, these calls are not always floated to the top-level, which means that they are redone everytime a comparison needs to be performed.

Redoing comparisons hurts performance of call and callStatic in the jvm package.

When using Prelude.String instead, the comparisons become pure, which allows their results to be floated and cached when call and callStatic are evaluated multiple times at the same types.