### PR TITLE
Make the result of JNI.String constructors bear the proof of well-formation.

### DIFF
--- a/jni/jni.cabal
+++ b/jni/jni.cabal
@@ -29,6 +29,7 @@ library
     Foreign.JNI
     Foreign.JNI.Types
     Foreign.JNI.String
+    Foreign.JNI.Internal
   other-modules:
     Foreign.JNI.NativeMethod
   build-depends:

--- a/jni/src/Foreign/JNI.cpphs
+++ b/jni/src/Foreign/JNI.cpphs
@@ -42,6 +42,10 @@ module Foreign.JNI
   , defineClass
   , JNINativeMethod(..)
   , registerNatives
+    -- ** String wrappers
+  , ReferenceTypeName
+  , MethodSignature
+  , Signature
     -- ** Exceptions
   , JVMException(..)
   , throw
@@ -187,6 +191,7 @@ import Foreign.ForeignPtr
   , newForeignPtr_
   , withForeignPtr
   )
+import Foreign.JNI.Internal
 import Foreign.JNI.NativeMethod
 import Foreign.JNI.Types
 import qualified Foreign.JNI.String as JNI
@@ -363,11 +368,11 @@ withJVM options action =
 
 defineClass
   :: Coercible o (J ('Class "java.lang.ClassLoader"))
-  => JNI.String -- ^ Class name
-  -> o          -- ^ Loader
+  => ReferenceTypeName -- ^ Class name
+  -> o -- ^ Loader
   -> ByteString -- ^ Bytecode buffer
   -> IO JClass
-defineClass name (coerce -> upcast -> loader) buf = withJNIEnv $ \env ->
+defineClass (coerce -> name) (coerce -> upcast -> loader) buf = withJNIEnv $ \env ->
     throwIfException env $
     JNI.withString name $ \namep ->
     objectFromPtr =<<
@@ -407,16 +412,16 @@ throwNew cls msg = withJNIEnv $ \env ->
                                    $(char *msgp)) } |]
 
 findClass
-  :: JNI.String -- ^ Class name
+  :: ReferenceTypeName -- ^ Class name
   -> IO JClass
-findClass name = withJNIEnv $ \env ->
+findClass (coerce -> name) = withJNIEnv $ \env ->
     throwIfException env $
     JNI.withString name $ \namep ->
     objectFromPtr =<<
     [CU.exp| jclass { (*$(JNIEnv *env))->FindClass($(JNIEnv *env), $(char *namep)) } |]
 
-newObject :: JClass -> JNI.String -> [JValue] -> IO JObject
-newObject cls sig args = withJNIEnv $ \env ->
+newObject :: JClass -> MethodSignature -> [JValue] -> IO JObject
+newObject cls (coerce -> sig) args = withJNIEnv $ \env ->
     throwIfException env $
     withJValues args $ \cargs -> do
       constr <- getMethodID cls "<init>" sig
@@ -429,9 +434,9 @@ newObject cls sig args = withJNIEnv $ \env ->
 getFieldID
   :: JClass -- ^ A class object as returned by 'findClass'
   -> JNI.String -- ^ Field name
-  -> JNI.String -- ^ JNI signature
+  -> Signature -- ^ JNI signature
   -> IO JFieldID
-getFieldID cls fieldname sig = withJNIEnv $ \env ->
+getFieldID cls fieldname (coerce -> sig) = withJNIEnv $ \env ->
     throwIfException env $
     JNI.withString fieldname $ \fieldnamep ->
     JNI.withString sig $ \sigp ->
@@ -444,9 +449,9 @@ getFieldID cls fieldname sig = withJNIEnv $ \env ->
 getStaticFieldID
   :: JClass -- ^ A class object as returned by 'findClass'
   -> JNI.String -- ^ Field name
-  -> JNI.String -- ^ JNI signature
+  -> Signature -- ^ JNI signature
   -> IO JFieldID
-getStaticFieldID cls fieldname sig = withJNIEnv $ \env ->
+getStaticFieldID cls fieldname (coerce -> sig) = withJNIEnv $ \env ->
     throwIfException env $
     JNI.withString fieldname $ \fieldnamep ->
     JNI.withString sig $ \sigp ->
@@ -551,9 +556,9 @@ SET_STATIC_FIELD(Double, Double, jdouble)
 getMethodID
   :: JClass -- ^ A class object as returned by 'findClass'
   -> JNI.String -- ^ Field name
-  -> JNI.String -- ^ JNI signature
+  -> MethodSignature -- ^ JNI signature
   -> IO JMethodID
-getMethodID cls methodname sig = withJNIEnv $ \env ->
+getMethodID cls methodname (coerce -> sig) = withJNIEnv $ \env ->
     throwIfException env $
     JNI.withString methodname $ \methodnamep ->
     JNI.withString sig $ \sigp ->
@@ -566,9 +571,9 @@ getMethodID cls methodname sig = withJNIEnv $ \env ->
 getStaticMethodID
   :: JClass -- ^ A class object as returned by 'findClass'
   -> JNI.String -- ^ Field name
-  -> JNI.String -- ^ JNI signature
+  -> MethodSignature -- ^ JNI signature
   -> IO JMethodID
-getStaticMethodID cls methodname sig = withJNIEnv $ \env ->
+getStaticMethodID cls methodname (coerce -> sig) = withJNIEnv $ \env ->
     throwIfException env $
     JNI.withString methodname $ \methodnamep ->
     JNI.withString sig $ \sigp ->

--- a/jni/src/Foreign/JNI/Internal.hs
+++ b/jni/src/Foreign/JNI/Internal.hs
@@ -1,0 +1,25 @@
+module Foreign.JNI.Internal where
+
+import qualified Foreign.JNI.String as JNI
+
+-- | A reference type name is not just any 'JNI.String', but a fully qualified
+-- identifier well-formed by construction.
+newtype ReferenceTypeName = ReferenceTypeName JNI.String
+  deriving (Eq, Ord)
+
+instance Show ReferenceTypeName where
+  show (ReferenceTypeName str) = show str
+
+-- | A string representing a signature, well-formed by construction.
+newtype Signature = Signature JNI.String
+  deriving (Eq, Ord)
+
+instance Show Signature where
+  show (Signature str) = show str
+
+-- | A string representing a signature, well-formed by construction.
+newtype MethodSignature = MethodSignature JNI.String
+  deriving (Eq, Ord)
+
+instance Show MethodSignature where
+  show (MethodSignature str) = show str

--- a/jni/src/Foreign/JNI/NativeMethod.hsc
+++ b/jni/src/Foreign/JNI/NativeMethod.hsc
@@ -6,6 +6,8 @@
 module Foreign.JNI.NativeMethod where
 
 import qualified Data.ByteString.Unsafe as BS
+import Data.Coerce (coerce)
+import Foreign.JNI.Internal
 import qualified Foreign.JNI.String as JNI
 import Foreign.Ptr (FunPtr)
 import Foreign.Storable (Storable(..))
@@ -18,7 +20,7 @@ import Foreign.Storable (Storable(..))
 
 data JNINativeMethod = forall a. JNINativeMethod
   { jniNativeMethodName :: JNI.String
-  , jniNativeMethodSignature :: JNI.String
+  , jniNativeMethodSignature :: MethodSignature
   , jniNativeMethodFunPtr :: FunPtr a
   }
 
@@ -32,9 +34,9 @@ instance Storable JNINativeMethod where
       return $
         JNINativeMethod
           (JNI.unsafeFromByteString name)
-          (JNI.unsafeFromByteString sig)
+          (coerce (JNI.unsafeFromByteString sig))
           fptr
   poke ptr JNINativeMethod{..} = do
       JNI.withString jniNativeMethodName $ #{poke JNINativeMethod, name} ptr
-      JNI.withString jniNativeMethodSignature $ #{poke JNINativeMethod, signature} ptr
+      JNI.withString (coerce jniNativeMethodSignature) $ #{poke JNINativeMethod, signature} ptr
       #{poke JNINativeMethod, fnPtr} ptr jniNativeMethodFunPtr

--- a/jvm/src/Language/Java.hs
+++ b/jvm/src/Language/Java.hs
@@ -426,8 +426,12 @@ withStatic [d|
 
   instance Reify Bool ('Class "java.lang.Boolean") where
     reify jobj = do
-        klass <- findClass "java/lang/Boolean"
-        method <- getMethodID klass "booleanValue" "()Z"
+        klass <- findClass (referenceTypeName (SClass "java.lang.Boolean"))
+        method <-
+          getMethodID
+            klass
+            "booleanValue"
+            (methodSignature [] (SPrim "boolean"))
         callBooleanMethod jobj method []
 
   instance Reflect Bool ('Class "java.lang.Boolean") where
@@ -437,8 +441,12 @@ withStatic [d|
 
   instance Reify Int16 ('Class "java.lang.Short") where
     reify jobj = do
-        klass <- findClass "java/lang/Short"
-        method <- getMethodID klass "shortValue" "()S"
+        klass <- findClass (referenceTypeName (SClass "java.lang.Short"))
+        method <-
+          getMethodID
+            klass
+            "shortValue"
+            (methodSignature [] (SPrim "short"))
         callShortMethod jobj method []
 
   instance Reflect Int16 ('Class "java.lang.Short") where
@@ -448,8 +456,12 @@ withStatic [d|
 
   instance Reify Int32 ('Class "java.lang.Integer") where
     reify jobj = do
-        klass <- findClass "java/lang/Integer"
-        method <- getMethodID klass "intValue" "()I"
+        klass <- findClass (referenceTypeName (SClass "java.lang.Integer"))
+        method <-
+          getMethodID
+            klass
+            "intValue"
+            (methodSignature [] (SPrim "int"))
         callIntMethod jobj method []
 
   instance Reflect Int32 ('Class "java.lang.Integer") where
@@ -459,8 +471,12 @@ withStatic [d|
 
   instance Reify Int64 ('Class "java.lang.Long") where
     reify jobj = do
-        klass <- findClass "java/lang/Long"
-        method <- getMethodID klass "longValue" "()J"
+        klass <- findClass (referenceTypeName (SClass "java.lang.Long"))
+        method <-
+          getMethodID
+            klass
+            "longValue"
+            (methodSignature [] (SPrim "long"))
         callLongMethod jobj method []
 
   instance Reflect Int64 ('Class "java.lang.Long") where
@@ -470,8 +486,12 @@ withStatic [d|
 
   instance Reify Word16 ('Class "java.lang.Character") where
     reify jobj = do
-        klass <- findClass "java/lang/Character"
-        method <- getMethodID klass "charValue" "()C"
+        klass <- findClass (referenceTypeName (SClass "java.lang.Character"))
+        method <-
+          getMethodID
+            klass
+            "charValue"
+            (methodSignature [] (SPrim "char"))
         fromIntegral <$> callCharMethod jobj method []
 
   instance Reflect Word16 ('Class "java.lang.Character") where
@@ -481,8 +501,12 @@ withStatic [d|
 
   instance Reify Double ('Class "java.lang.Double") where
     reify jobj = do
-        klass <- findClass "java/lang/Double"
-        method <- getMethodID klass "doubleValue" "()D"
+        klass <- findClass (referenceTypeName (SClass "java.lang.Double"))
+        method <-
+          getMethodID
+            klass
+            "doubleValue"
+            (methodSignature [] (SPrim "double"))
         callDoubleMethod jobj method []
 
   instance Reflect Double ('Class "java.lang.Double") where
@@ -492,8 +516,12 @@ withStatic [d|
 
   instance Reify Float ('Class "java.lang.Float") where
     reify jobj = do
-        klass <- findClass "java/lang/Float"
-        method <- getMethodID klass "floatValue" "()F"
+        klass <- findClass (referenceTypeName (SClass "java.lang.Float"))
+        method <-
+          getMethodID
+            klass
+            "floatValue"
+            (methodSignature [] (SPrim "float"))
         callFloatMethod jobj method []
 
   instance Reflect Float ('Class "java.lang.Float") where


### PR DESCRIPTION
678d5b1416df435f84fe31ff1110eb15480f96c6 showed how it is all too easy
to pass an ill-formed class name to findClass. We do get a runtime
error in this case but sometimes the error returned by the JVM is
confusing. Better to statically rule out the possibility of
a well-formation issue to begin with. That's what the abstract newtype
wrappers introduced here seek to achieve: extra safety and piece of
mind.

Note that this patch doesn't actually validate much (can always add
more validations in the future), but it at least enforces a style
where only Java surface syntax "dotty" names are used uniformly, so
you should now never need to worry about JNI style "slashy" names.

This is a backward compatibility breaking change.

cc @robinbb @edsko @alpmestan