### PR TITLE
Add an example application to show how to set the classpath.

### DIFF
--- a/examples/classpath/Main.hs
+++ b/examples/classpath/Main.hs
@@ -2,11 +2,13 @@
 {-# LANGUAGE QuasiQuotes #-}
 module Main where
 
+import Data.Int (Int32)
+import Foreign.JNI (withJVM)
 import Language.Java.Inline
 import Language.Java.Inline.Cabal (gradleHooks)
 
-main :: IO ()
-main = [java| {
+main :: IO Int32
+main = withJVM [] $ [java| {
     org.apache.commons.collections4.OrderedMap map =
       new org.apache.commons.collections4.map.LinkedMap();
     map.put("FIVE", "5");
@@ -15,5 +17,6 @@ main = [java| {
     System.out.println(map.firstKey());
     System.out.println(map.nextKey("FIVE"));
     System.out.println(map.nextKey("SIX"));
+    return 0;
     }
  |]

--- a/examples/classpath/Main.hs
+++ b/examples/classpath/Main.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QuasiQuotes #-}
+module Main where
+
+import Language.Java.Inline
+import Language.Java.Inline.Cabal (gradleHooks)
+
+main :: IO ()
+main = [java| {
+    org.apache.commons.collections4.OrderedMap map =
+      new org.apache.commons.collections4.map.LinkedMap();
+    map.put("FIVE", "5");
+    map.put("SIX", "6");
+    map.put("SEVEN", "7");
+    System.out.println(map.firstKey());
+    System.out.println(map.nextKey("FIVE"));
+    System.out.println(map.nextKey("SIX"));
+    }
+ |]

--- a/examples/classpath/Main.hs
+++ b/examples/classpath/Main.hs
@@ -3,20 +3,24 @@
 module Main where
 
 import Data.Int (Int32)
+import Data.String (fromString)
 import Foreign.JNI (withJVM)
 import Language.Java.Inline
 import Language.Java.Inline.Cabal (gradleHooks)
+import System.Environment (getArgs)
 
 main :: IO Int32
-main = withJVM [] $ [java| {
-    org.apache.commons.collections4.OrderedMap map =
-      new org.apache.commons.collections4.map.LinkedMap();
-    map.put("FIVE", "5");
-    map.put("SIX", "6");
-    map.put("SEVEN", "7");
-    System.out.println(map.firstKey());
-    System.out.println(map.nextKey("FIVE"));
-    System.out.println(map.nextKey("SIX"));
-    return 0;
-    }
- |]
+main = do
+    args <- getArgs
+    withJVM (map fromString args) $ [java| {
+      org.apache.commons.collections4.OrderedMap map =
+        new org.apache.commons.collections4.map.LinkedMap();
+      map.put("FIVE", "5");
+      map.put("SIX", "6");
+      map.put("SEVEN", "7");
+      System.out.println(map.firstKey());
+      System.out.println(map.nextKey("FIVE"));
+      System.out.println(map.nextKey("SIX"));
+      return 0;
+      }
+   |]

--- a/examples/classpath/Setup.hs
+++ b/examples/classpath/Setup.hs
@@ -1,0 +1,4 @@
+import Distribution.Simple
+import Language.Java.Inline.Cabal (gradleHooks)
+
+main = defaultMainWithHooks (gradleHooks simpleUserHooks)

--- a/examples/classpath/build.gradle
+++ b/examples/classpath/build.gradle
@@ -1,0 +1,23 @@
+apply plugin: 'java'
+apply plugin: 'application'
+
+mainClassName = "Classpath"
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  compile 'org.apache.commons:commons-collections4:4.1'
+}
+
+compileJava {
+  sourceCompatibility = 1.7
+  targetCompatibility = 1.7
+}
+
+jar {
+  manifest {
+    attributes "Main-Class": "Classpath"
+  }
+}

--- a/examples/classpath/classpath.cabal
+++ b/examples/classpath/classpath.cabal
@@ -12,5 +12,5 @@ custom-setup
 
 executable classpath
   main-is:             Main.hs
-  build-depends:       base<5, inline-java
+  build-depends:       base<5, jni, inline-java, template-haskell
   default-language:    Haskell2010

--- a/examples/classpath/classpath.cabal
+++ b/examples/classpath/classpath.cabal
@@ -1,0 +1,16 @@
+name:                classpath
+version:             0.1
+synopsis:            An example application showing how to set the classpath for inline-java.
+author:              EURL Tweag
+maintainer:          facundo.dominguez@tweag.io
+copyright:           2017 EURL Tweag.
+build-type:          Custom
+cabal-version:       >=1.18
+
+custom-setup
+  setup-depends: Cabal>=1.18, base<5, inline-java
+
+executable classpath
+  main-is:             Main.hs
+  build-depends:       base<5, inline-java
+  default-language:    Haskell2010

--- a/examples/classpath/settings.gradle
+++ b/examples/classpath/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'classpath'

--- a/examples/classpath/src/main/java/Classpath.java
+++ b/examples/classpath/src/main/java/Classpath.java
@@ -1,0 +1,10 @@
+
+public class Classpath {
+
+  public static void main(String[] args) {
+    org.apache.commons.collections4.OrderedMap map =
+      new org.apache.commons.collections4.map.LinkedMap();
+    map.put("FIVE", "5");
+    System.out.println(map.firstKey());
+  }
+}

--- a/shell.nix
+++ b/shell.nix
@@ -17,7 +17,7 @@ let
 in
 haskell.lib.buildStackProject ({
   name = "inline-java";
-  buildInputs = [ git openjdk ];
+  buildInputs = [ git openjdk gradle ];
   ghc = haskell.compiler.ghc802;
   extraArgs = ["--extra-lib-dirs=${jvmlibdir}"];
   LANG = "en_US.utf8";

--- a/src/Language/Java/Inline/Cabal.hs
+++ b/src/Language/Java/Inline/Cabal.hs
@@ -28,8 +28,8 @@ import System.Process (callProcess, readProcess)
 -- | Adds the 'setGradleClasspath' and 'gradleBuild' hooks.
 gradleHooks :: UserHooks -> UserHooks
 gradleHooks hooks = hooks
-    { preBuild = setGradleClasspath >> preBuild hooks
-    , buildHook = buildHook hooks >> gradleBuild
+    { preBuild = \a b -> setGradleClasspath a b >> preBuild hooks a b
+    , buildHook = \a b c d -> gradleBuild a b c d >> buildHook hooks a b c d
     }
 
 gradleBuildFile :: FilePath

--- a/src/Language/Java/Inline/Cabal.hs
+++ b/src/Language/Java/Inline/Cabal.hs
@@ -53,6 +53,8 @@ getGradleClasspath parentBuildfile = do
           , "task classpath { doLast { println sourceSets.main.compileClasspath.getAsPath() } }"
           ]
       readProcess "gradle" ["-q", "-b", buildfile, "classpath"] ""
+        -- trim trailing newlines
+        >>= return . concat . lines
 
 -- | Set the @CLASSPATH@ from a Gradle build configuration. Does not override
 -- the @CLASSPATH@ if one exists.

--- a/src/Language/Java/Inline/Cabal.hs
+++ b/src/Language/Java/Inline/Cabal.hs
@@ -28,7 +28,7 @@ import System.Process (callProcess, readProcess)
 -- | Adds the 'setGradleClasspath' and 'gradleBuild' hooks.
 gradleHooks :: UserHooks -> UserHooks
 gradleHooks hooks = hooks
-    { preBuild = setGradleClasspath
+    { preBuild = setGradleClasspath >> preBuild hooks
     , buildHook = buildHook hooks >> gradleBuild
     }
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,6 +5,7 @@ packages:
 - jni
 - jvm
 - jvm-streaming
+- location: examples/classpath
 
 extra-deps:
 - choice-0.2.0


### PR DESCRIPTION
`stack-1.3.2` fails to build Setup.hs. 
```
stack --nix build classpath
...
/home/facundo/tweag/leapyear/leapyear-sparkle/inline-java/examples/classpath/Setup.hs:2:1: error:
    Failed to load interface for ‘Language.Java.Inline.Cabal’
    Use -v to see a list of the files searched for.
```

`cabal-install` fails in a different place
```
$ cabal --version
cabal-install version 1.24.0.0
compiled using version 1.24.0.0 of the Cabal library 
$ PATH=...gradle-3.3/bin:...ghc-8.0.2/bin:$PATH cabal install ./examples/classpath . jni/ jvm/ --extra-lib-dirs=...jre/lib/amd64/server --extra-include-dir=...openjdk-8u121b13/include
...
Installing executable(s) in /home/facundo/.cabal/bin
dist/build/classpath/classpath: copyFile: does not exist (No such file or
directory)
cabal: Leaving directory './examples/classpath'
cabal: Error: some packages failed to install:
classpath-0.1 failed during the final install step. The exception was:
ExitFailure 1
```
Setup runs `gradle build`, but the folder `examples/classpath/dist/build` is empty.

We need to figure out both failures.