### PR TITLE
Pass class name as a JNI.String to callStatic, not as a singleton.

### DIFF
--- a/jvm/tests/Language/JavaSpec.hs
+++ b/jvm/tests/Language/JavaSpec.hs
@@ -17,18 +17,18 @@ spec = do
     describe "callStatic" $ do
       it "can call double-returning static functions" $ do
         jstr <- reflect ("1.2345" :: Text)
-        callStatic (sing :: Sing "java.lang.Double") "parseDouble" [coerce jstr]
+        callStatic "java.lang.Double" "parseDouble" [coerce jstr]
           `shouldReturn` (1.2345 :: Double)
 
       it "can call int-returning static functions" $ do
         jstr <- reflect ("12345" :: Text)
-        callStatic (sing :: Sing "java.lang.Integer") "parseInt" [coerce jstr]
+        callStatic "java.lang.Integer" "parseInt" [coerce jstr]
           `shouldReturn` (12345 :: Int32)
 
       it "can call String-returning static functions" $ do
         jstr <-
           callStatic
-            (sing :: Sing "java.lang.Integer")
+            "java.lang.Integer"
             "toString"
             [coerce (12345 :: Int32)]
         reify jstr `shouldReturn` ("12345" :: Text)
@@ -36,25 +36,25 @@ spec = do
       it "short doesn't under- or overflow" $ do
         maxshort <- reflect (Text.pack (show (maxBound :: Int16)))
         minshort <- reflect (Text.pack (show (minBound :: Int16)))
-        callStatic (sing :: Sing "java.lang.Short") "parseShort" [coerce maxshort]
+        callStatic "java.lang.Short" "parseShort" [coerce maxshort]
           `shouldReturn` (maxBound :: Int16)
-        callStatic (sing :: Sing "java.lang.Short") "parseShort" [coerce minshort]
+        callStatic "java.lang.Short" "parseShort" [coerce minshort]
           `shouldReturn` (minBound :: Int16)
 
       it "int doesn't under- or overflow" $ do
         maxint <- reflect (Text.pack (show (maxBound :: Int32)))
         minint <- reflect (Text.pack (show (minBound :: Int32)))
-        callStatic (sing :: Sing "java.lang.Integer") "parseInt" [coerce maxint]
+        callStatic "java.lang.Integer" "parseInt" [coerce maxint]
           `shouldReturn` (maxBound :: Int32)
-        callStatic (sing :: Sing "java.lang.Integer") "parseInt" [coerce minint]
+        callStatic "java.lang.Integer" "parseInt" [coerce minint]
           `shouldReturn` (minBound :: Int32)
 
       it "long doesn't under- or overflow" $ do
         maxlong <- reflect (Text.pack (show (maxBound :: Int64)))
         minlong <- reflect (Text.pack (show (minBound :: Int64)))
-        callStatic (sing :: Sing "java.lang.Long") "parseLong" [coerce maxlong]
+        callStatic "java.lang.Long" "parseLong" [coerce maxlong]
           `shouldReturn` (maxBound :: Int64)
-        callStatic (sing :: Sing "java.lang.Long") "parseLong" [coerce minlong]
+        callStatic "java.lang.Long" "parseLong" [coerce minlong]
           `shouldReturn` (minBound :: Int64)
 
     describe "newArray" $ do


### PR DESCRIPTION
The original rationale for passing in a singleton was that like `call` and
other functions, it becomes possible to `SPECIALIZE` `callStatic` to
certain classes. But this isn't terribly useful, indeed entirely redundant
with what could be achieved with simple inlinining, hence making the added
syntactic overhead unjustifiable.

```
callStatic (sing :: Sing "some.java.Class") ...
```

is now

```
callStatic "some.java.Class" ...
```

This is a breaking change. Best to change this now before this really
becomes enshrined.

cc @alpmestan :)