### PR TITLE
Extend newArray to work over any reference type. (#24)

### DIFF
--- a/jni/jni.cabal
+++ b/jni/jni.cabal
@@ -37,6 +37,7 @@ library
     bytestring >=0.10,
     choice >= 0.2.0,
     containers >=0.5,
+    constraints >=0.8,
     inline-c >=0.5.6.1,
     singletons >= 2.0,
     thread-local-storage >=0.1

--- a/jni/src/Foreign/JNI/Types.hs
+++ b/jni/src/Foreign/JNI/Types.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -31,6 +32,7 @@ module Foreign.JNI.Types
   , unsafeUngeneric
   , jtypeOf
   , ReferenceTypeName
+  , singToIsReferenceType
   , referenceTypeName
   , Signature
   , signature
@@ -66,6 +68,7 @@ import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Builder.Prim as Prim
 import Data.ByteString.Builder (Builder)
 import Data.Char (chr, ord)
+import Data.Constraint (Dict(..))
 import Data.Int
 import qualified Data.Map as Map
 import Data.Monoid ((<>))
@@ -77,6 +80,7 @@ import Data.Singletons
   , KProxy(..)
 #endif
   )
+import Data.Singletons.Prelude (Sing(..))
 import Data.Singletons.TypeLits (KnownSymbol, symbolVal)
 import Data.Word
 import Foreign.C (CChar)
@@ -133,6 +137,16 @@ instance IsReferenceType ('Iface sym)
 instance IsReferenceType ('Array ty)
 instance IsReferenceType ty => IsReferenceType ('Generic ty tys)
 
+-- | Produces evidence for IsReferenceType from a `Sing ty`.
+singToIsReferenceType :: Sing (ty :: JType) -> Maybe (Dict (IsReferenceType ty))
+singToIsReferenceType tysing = case tysing of
+    SClass _ -> Just Dict
+    SPrim _ -> Nothing
+    SIface _ -> Just Dict
+    SArray _ -> Just Dict
+    SGeneric tysing' _ -> (\Dict -> Dict) <$> singToIsReferenceType tysing'
+    SVoid -> Nothing
+
 data instance Sing (a :: JType) where
   -- Using String instead of JNI.String for the singleton data constructors
   -- is an optimization. Otherwise, the comparisons in Language.Java.call
@@ -145,6 +159,24 @@ data instance Sing (a :: JType) where
   SArray :: Sing ty -> Sing ('Array ty)
   SGeneric :: Sing ty -> Sing tys -> Sing ('Generic ty tys)
   SVoid :: Sing 'Void
+
+instance Show (Sing (a :: JType)) where
+  showsPrec d (SClass s) = showParen (d > 10) $
+      showString "SClass " . showsPrec 11 s
+  showsPrec d (SIface s) = showParen (d > 10) $
+      showString "SIface " . showsPrec 11 s
+  showsPrec d (SPrim s) = showParen (d > 10) $
+      showString "SPrim " . showsPrec 11 s
+  showsPrec d (SArray s) = showParen (d > 10) $
+      showString "SArray " . showsPrec 11 s
+  showsPrec d (SGeneric s sargs) = showParen (d > 10) $
+      showString "SGeneric " . showsPrec 11 s . showsPrec 11 sargs
+  showsPrec _ SVoid = showString "SVoid"
+
+instance Show (Sing (a :: [JType])) where
+  showsPrec _ SNil = showString "SNil"
+  showsPrec d (SCons ty tys) = showParen (d > 10) $
+      showString "SCons " . showsPrec 11 ty . showChar ' ' . showsPrec 11 tys
 
 -- XXX SingI constraint temporary hack because GHC 7.10 has trouble inferring
 -- this constraint in 'signature'.

--- a/jvm/jvm.cabal
+++ b/jvm/jvm.cabal
@@ -25,6 +25,7 @@ library
   build-depends:
     base >= 4.7 && < 5,
     bytestring >=0.10,
+    constraints >= 0.8,
     distributed-closure >=0.3,
     jni >= 0.3.0,
     singletons >= 2.0,

--- a/jvm/src/Language/Java.hs
+++ b/jvm/src/Language/Java.hs
@@ -73,6 +73,7 @@ import Control.Exception (Exception, throw, finally)
 import Control.Monad
 import Data.Char (chr, ord)
 import qualified Data.Coerce as Coerce
+import Data.Constraint (Dict(..))
 import Data.Int
 import Data.Typeable (Typeable, TypeRep, typeOf)
 import Data.Word
@@ -243,13 +244,16 @@ newArray sz = do
       SPrim "long" -> unsafeCast <$> newLongArray sz
       SPrim "float" -> unsafeCast <$> newFloatArray sz
       SPrim "double" -> unsafeCast <$> newDoubleArray sz
-      SClass _cls -> unsafeCast <$> newObjectArray sz klass
-        where
-          klass =
-            unsafeDupablePerformIO $
-            findClass (referenceTypeName tysing) >>= newGlobalRef
-      _ -> fail "newArray only supports primitive types and objects"
-
+      SVoid -> fail "newArray of void"
+      _ -> case singToIsReferenceType tysing of
+        Nothing -> fail $ "newArray of " ++ show tysing
+        Just Dict -> do
+          let klass = unsafeDupablePerformIO $ do
+                lk <- findClass (referenceTypeName tysing)
+                gk <- newGlobalRef lk
+                deleteLocalRef lk
+                return gk
+          unsafeCast <$> newObjectArray sz klass
 
 -- | The Swiss Army knife for calling Java methods. Give it an object or
 -- any data type coercible to one, the name of a method, and a list of

--- a/jvm/tests/Language/JavaSpec.hs
+++ b/jvm/tests/Language/JavaSpec.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Language.JavaSpec where
 
@@ -71,3 +72,8 @@ spec = do
       it "Supports object arrays" $ do
         xs :: [JObject] <- reify =<< newArray 10
         length xs `shouldBe` 10
+
+      it "supports generics" $ do
+        xs <- reify =<< newArray 10
+        length (xs :: [J ('Class "java.util.List" <> '[Class "java.lang.Long"])])
+          `shouldBe` 10


### PR DESCRIPTION
* Implement instance Show (Sing (a :: JType)).

* Construct IsReferenceType instances from Sing values.