### PR TITLE
Make Choice Coercible to a Java boolean.

### DIFF
--- a/jvm/jvm.cabal
+++ b/jvm/jvm.cabal
@@ -26,6 +26,7 @@ library
     base >= 4.7 && < 5,
     bytestring >=0.10,
     constraints >= 0.8,
+    choice >= 0.1,
     distributed-closure >=0.3,
     jni >= 0.3.0,
     singletons >= 2.0,

--- a/jvm/src/Language/Java.hs
+++ b/jvm/src/Language/Java.hs
@@ -72,6 +72,7 @@ import Control.Distributed.Closure.TH
 import Control.Exception (Exception, throw, finally)
 import Control.Monad
 import Data.Char (chr, ord)
+import qualified Data.Choice as Choice
 import qualified Data.Coerce as Coerce
 import Data.Constraint (Dict(..))
 import Data.Int
@@ -184,6 +185,9 @@ instance Coercible Double ('Prim "double") where
 instance Coercible () 'Void where
   coerce = error "Void value undefined."
   unsafeUncoerce _ = ()
+instance Coercible (Choice.Choice a) ('Prim "boolean") where
+  coerce = coerce . Choice.toBool
+  unsafeUncoerce = Choice.fromBool . unsafeUncoerce
 
 -- | Get the Java class of an object or anything 'Coercible' to one.
 classOf


### PR DESCRIPTION
This is useful for using inline-java in sparkle. Instance needs to be
defined in jvm package to avoid orphan instances.