### PR TITLE
Support for unlifting Java generics.

### DIFF
--- a/src/Language/Java/Inline.hs
+++ b/src/Language/Java/Inline.hs
@@ -49,11 +49,11 @@ module Language.Java.Inline
   ( java
   ) where
 
-import Control.Monad (forM_, unless)
+import Control.Monad (forM_, unless, when)
 import qualified Data.ByteString.Char8 as BS
 import Data.Char (isAlphaNum)
-import Data.Generics (everything, everywhereM, mkM, mkQ)
-import Data.List (intercalate, isPrefixOf, isSuffixOf)
+import Data.Generics (everything, everywhere, gmapM, mkM, mkQ, mkT)
+import Data.List (intercalate, isPrefixOf, isSuffixOf, lookup)
 import Data.Maybe (fromJust)
 import Data.Singletons (SomeSing(..))
 import Data.String (fromString)
@@ -399,14 +399,29 @@ blockQQ input = case Java.parser Java.block input of
       -- lifted, we'll support returning unboxed values, just like `call` does.
       castReturnType funcall = [| unsafeUncoerce . coerce <$> $funcall |]
 
+-- | Non capture-avoiding substitution. The argument type should not contain any
+-- variable binding forms.
+substType :: [(TH.Name, TH.Type)] -> TH.Type -> TH.Type
+substType ctx = everywhere (mkT go)
+  where
+    go (TH.VarT name) | Just ty' <- lookup name ctx = ty'
+    go TH.ForallT{} = error "substType: forall not supported."
+    go ty = ty
+
 -- Recursively unfold type synonyms, if any.
 unfoldTypeTySyn :: TH.Type -> Q TH.Type
-unfoldTypeTySyn = everywhereM (mkM go)
+unfoldTypeTySyn ty
+  | (TH.ConT name, actuals) <- decomp [] ty =
+    TH.reify name >>= \case
+      TH.TyConI (TH.TySynD _ (map fromBndr -> parms) ty') -> do
+        when (length actuals < length parms) $
+          -- In principle GHC would never let this happen anyways.
+          fail "Internal error: type synonym not fully saturated."
+        unfoldTypeTySyn (substType (zip parms actuals) ty')
+      _ -> gmapM (mkM unfoldTypeTySyn) ty
+  | otherwise = gmapM (mkM unfoldTypeTySyn) ty
   where
-    go ty@(TH.ConT name) =
-      TH.reify name >>= \case
-        TH.TyConI (TH.TySynD _ [] ty') -> unfoldTypeTySyn ty'
-        TH.TyConI (TH.TySynD _ _ _) -> fail $
-          "unfoldTypeTySyn: Type synonyms with type variables are not currently supported: " ++ show name
-        _ -> pure ty
-    go ty = return ty
+    decomp tys (TH.AppT ty1 ty2) = decomp (ty2:tys) ty1
+    decomp tys ty1 = (ty1, tys)
+    fromBndr (TH.PlainTV n) = n
+    fromBndr (TH.KindedTV n _) = n

--- a/src/Language/Java/Inline.hs
+++ b/src/Language/Java/Inline.hs
@@ -52,7 +52,7 @@ module Language.Java.Inline
 import Control.Monad (forM_, unless)
 import qualified Data.ByteString.Char8 as BS
 import Data.Char (isAlphaNum)
-import Data.Generics (everything, mkQ)
+import Data.Generics (everything, everywhereM, mkM, mkQ)
 import Data.List (intercalate, isPrefixOf, isSuffixOf)
 import Data.Maybe (fromJust)
 import Data.Singletons (SomeSing(..))
@@ -401,38 +401,12 @@ blockQQ input = case Java.parser Java.block input of
 
 -- Recursively unfold type synonyms, if any.
 unfoldTypeTySyn :: TH.Type -> Q TH.Type
-unfoldTypeTySyn = \case
-    -- The workhorse
-    ty@(TH.ConT name) ->
+unfoldTypeTySyn = everywhereM (mkM go)
+  where
+    go ty@(TH.ConT name) =
       TH.reify name >>= \case
         TH.TyConI (TH.TySynD _ [] ty') -> unfoldTypeTySyn ty'
         TH.TyConI (TH.TySynD _ _ _) -> fail $
           "unfoldTypeTySyn: Type synonyms with type variables are not currently supported: " ++ show name
         _ -> pure ty
-
-    -- The boilerplate
-    TH.ForallT tvs ctx ty -> TH.ForallT
-      <$> mapM unfoldTyVarBndrTySyn tvs
-      <*> mapM unfoldTypeTySyn ctx
-      <*> unfoldTypeTySyn ty
-    TH.AppT f x -> TH.AppT
-      <$> unfoldTypeTySyn f
-      <*> unfoldTypeTySyn x
-    TH.SigT ty kind -> TH.SigT
-      <$> unfoldTypeTySyn ty
-      <*> unfoldTypeTySyn kind
-    TH.InfixT ty1 name ty2 -> TH.InfixT
-      <$> unfoldTypeTySyn ty1
-      <*> pure name
-      <*> unfoldTypeTySyn ty2
-    TH.UInfixT ty1 name ty2 -> TH.UInfixT
-      <$> unfoldTypeTySyn ty1
-      <*> pure name
-      <*> unfoldTypeTySyn ty2
-    TH.ParensT ty -> TH.ParensT <$> unfoldTypeTySyn ty
-    ty -> pure ty
-  where
-    unfoldTyVarBndrTySyn :: TH.TyVarBndr -> Q TH.TyVarBndr
-    unfoldTyVarBndrTySyn = \case
-        b@(TH.PlainTV _) -> pure b
-        TH.KindedTV var kind -> TH.KindedTV var <$> unfoldTypeTySyn kind
+    go ty = return ty

--- a/tests/Language/Java/InlineSpec.hs
+++ b/tests/Language/Java/InlineSpec.hs
@@ -1,20 +1,24 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ExplicitNamespaces #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
 -- Test that inline-java produces code without warnings.
 {-# OPTIONS_GHC -Wall -Werror #-}
 
 module Language.Java.InlineSpec(spec) where
 
 import Data.Int
-import Foreign.JNI.Types (JObject)
+import Foreign.JNI.Types (JObject, type (<>))
 import Language.Java
 import Language.Java.Inline
 import Test.Hspec
 
 type ObjectClass = 'Class "java.lang.Object"
+type ListClass = 'Class "java.util.List"
 
 type JJObject = JObject
+type List a = J (ListClass <> '[a])
 
 spec :: Spec
 spec = do
@@ -50,6 +54,11 @@ spec = do
           obj <- [java| new Object() {} |]
           let obj1 = obj :: JJObject
           _ :: JJObject <- [java| $obj1 |]
+          return ()
+
+        it "Supports parameterized type synonyms" $ do
+          obj :: List ObjectClass <- [java| new Object() {} |]
+          _ :: List ObjectClass <- [java| $obj |]
           return ()
 
       it "Supports multiple antiquotation variables" $ do


### PR DESCRIPTION
This makes it possible to have antiquotation variables with generic
parameters. The parameters must still be ground, since inline-java
needs to know at compile time the full types of all variables.