### PR TITLE
Make antiquoted variables final

### DIFF
--- a/jvm/benchmarks/Main.hs
+++ b/jvm/benchmarks/Main.hs
@@ -11,11 +11,11 @@ import Language.Java
 import Foreign.JNI
 import Criterion.Main as Criterion
 
-incrementExact :: Int32 -> IO Int32
-incrementExact x = callStatic (sing :: Sing "java.lang.Math") "incrementExact" [coerce x]
+jabs :: Int32 -> IO Int32
+jabs x = callStatic (sing :: Sing "java.lang.Math") "abs" [coerce x]
 
-jniIncrementExact :: JClass -> JMethodID -> Int32 -> IO Int32
-jniIncrementExact klass method x = callStaticIntMethod klass method [coerce x]
+jniAbs :: JClass -> JMethodID -> Int32 -> IO Int32
+jniAbs klass method x = callStaticIntMethod klass method [coerce x]
 
 intValue :: Int32 -> IO Int32
 intValue x = do
@@ -36,11 +36,11 @@ foreign import ccall unsafe getpid :: IO Int
 main :: IO ()
 main = withJVM [] $ do
     klass <- findClass "java/lang/Math"
-    method <- getStaticMethodID klass "incrementExact" "(I)I"
+    method <- getStaticMethodID klass "abs" "(I)I"
     Criterion.defaultMain
       [ bgroup "Java calls"
-        [ bench "static method call: unboxed single arg / unboxed return" $ nfIO $ incrementExact 1
-        , bench "jni static method call: unboxed single arg / unboxed return" $ nfIO $ jniIncrementExact klass method 1
+        [ bench "static method call: unboxed single arg / unboxed return" $ nfIO $ jabs 1
+        , bench "jni static method call: unboxed single arg / unboxed return" $ nfIO $ jniAbs klass method 1
         , bench "method call: no args / unboxed return" $ nfIO $ intValue 1
         , bench "method call: boxed single arg / unboxed return" $ nfIO $ compareTo 1 1
         ]

--- a/src/Language/Java/Inline.hs
+++ b/src/Language/Java/Inline.hs
@@ -156,7 +156,9 @@ abstract mname retty vtys block =
     Java.MethodDecl [Java.Public, Java.Static] [] retty mname params [] body
   where
     body = Java.MethodBody (Just block)
-    params = [ Java.FormalParam [] ty False (Java.VarId v) | (v, ty) <- vtys ]
+    params = [ Java.FormalParam [Java.Final] ty False (Java.VarId v)
+             | (v, ty) <- vtys
+             ]
 
 -- | Decode a TH 'Type' into a 'JType'. So named because it's morally the
 -- inverse of 'Language.Haskell.TH.Syntax.lift'.

--- a/tests/Language/Java/InlineSpec.hs
+++ b/tests/Language/Java/InlineSpec.hs
@@ -71,3 +71,8 @@ spec = do
 
       it "Supports multiple anonymous classes" $ do
         ([java| new Object() {}.equals(new Object() {}) |] >>= reify) `shouldReturn` False
+
+      it "Supports using antiquotation variables in inner classes" $ do
+        let foo = 1 :: Int32
+        ([java| { class Foo { int f() { return $foo; } }; return 1; } |]
+          >>= reify) `shouldReturn` (1 :: Int32)


### PR DESCRIPTION
Otherwise jdk 1.7 complains when antiquotations are used in inner classes.