### PR TITLE
Better handling of newtype wrappers.

### DIFF
--- a/jvm/jvm.cabal
+++ b/jvm/jvm.cabal
@@ -22,6 +22,7 @@ library
   hs-source-dirs: src
   exposed-modules:
     Language.Java
+    Language.Java.TH
   build-depends:
     base >= 4.7 && < 5,
     bytestring >=0.10,
@@ -30,6 +31,7 @@ library
     distributed-closure >=0.3,
     jni >= 0.3.0,
     singletons >= 2.0,
+    template-haskell >= 2.10,
     text >=1.2,
     vector >=0.11
   default-language: Haskell2010

--- a/jvm/src/Language/Java.hs
+++ b/jvm/src/Language/Java.hs
@@ -57,6 +57,7 @@ module Language.Java
   , callStatic
   , getStaticField
   , jvalue
+  , jobject
   , CoercionFailure(..)
   , Coercible(..)
   , Reify(..)

--- a/jvm/src/Language/Java.hs
+++ b/jvm/src/Language/Java.hs
@@ -364,6 +364,13 @@ getStaticField cname fname = do
 jvalue :: Coercible a ty => a -> JValue
 jvalue = coerce
 
+-- | If @ty@ is a reference type, then it should be possible to get an object
+-- from a value.
+jobject :: (Coercible a ty, IsReferenceType ty) => a -> J ty
+jobject x
+  | JObject jobj <- coerce x = unsafeCast jobj
+  | otherwise = error "impossible"
+
 -- | Classifies Java types according to whether they are base types (data) or
 -- higher-order types (objects representing functions).
 data Type a
@@ -407,6 +414,9 @@ class (Interp (Uncurry a) ~ ty, SingI ty, IsReferenceType ty)
       => Reify a ty where
   reify :: J ty -> IO a
 
+  default reify :: Coercible a ty => J ty -> IO a
+  reify x = (unsafeUncoerce . JObject) <$> newGlobalRef x
+
 -- | Inject a concrete Haskell value into the space of Java objects. That is to
 -- say, marshall a Haskell value to a Java object. Unlike coercing, in general
 -- reflection induces allocations and copies.
@@ -415,6 +425,9 @@ class (Interp (Uncurry a) ~ ty, SingI ty, IsReferenceType ty)
 class (Interp (Uncurry a) ~ ty, SingI ty, IsReferenceType ty)
       => Reflect a ty where
   reflect :: a -> IO (J ty)
+
+  default reflect :: Coercible a ty => a -> IO (J ty)
+  reflect x = newLocalRef (jobject x)
 
 #if ! (__GLASGOW_HASKELL__ == 800 && __GLASGOW_HASKELL_PATCHLEVEL1__ == 1)
 reifyMVector

--- a/jvm/src/Language/Java/TH.hs
+++ b/jvm/src/Language/Java/TH.hs
@@ -1,0 +1,46 @@
+-- | Optional code macros for convenience.
+
+{-# LANGUAGE TemplateHaskell #-}
+
+module Language.Java.TH (makeConversions) where
+
+import Control.Distributed.Closure.TH (withStatic)
+import qualified Language.Haskell.TH as TH
+import Language.Java
+
+-- | Define instances of the three conversion classes, 'Coercible', 'Reify' and
+-- 'Reflect' for the given datatype. Example usage:
+--
+-- @
+-- import qualified Language.Java.TH as Java
+--
+-- newtype JOptionPane = JOptionPane (J ('Class "javax.swing.JOptionPane"))
+-- Java.makeConversions ''JOptionPane
+-- @
+--
+-- This is equivalent to:
+--
+-- @
+-- newtype JOptionPane = JOptionPane (J ('Class "javax.swing.JOptionPane"))
+-- instance Coercible JOptionPane ('Class "javax.swing.JOptionPane")
+-- instance Reify JOptionPane ('Class "javax.swing.JOptionPane")
+-- instance Reflect JOptionPane ('Class "javax.swing.JOptionPane")
+-- @
+makeConversions :: TH.Name -> TH.Q [TH.Dec]
+makeConversions x = do
+    info <- TH.reify x
+    let ty_x = return (TH.ConT x)
+        ty_cls = case info of
+          TH.TyConI (TH.DataD [] _ _ _ [cstr] _) -> case cstr of
+            TH.NormalC _ [(_, TH.AppT (TH.ConT nm) ty)] | nm == ''J -> return ty
+            TH.RecC _ [(_, _, TH.AppT (TH.ConT nm) ty)] | nm == ''J -> return ty
+            _ -> notsupported
+          _ -> notsupported
+    withStatic [d|
+      instance Coercible $ty_x $ty_cls
+      instance Reify $ty_x $ty_cls
+      instance Reflect $ty_x $ty_cls
+      |]
+  where
+    notsupported = fail
+      "makeConversions failed. Only newtype wrappers of (J ty) are supported."


### PR DESCRIPTION
See the various commit messages in this series for details. This PR
adds:

* A new function `jobject`, which extracts a `J ty` from anything that
  is coercible, provided `ty` is a reference type.
* defaults for `Reify` and `Reflect` when a `Coercible` instance
  already exists.
* A new TH macro, `makeConversions`, designed to make it much less
  verbose to define a newtype wrapper. The desugaring of this macro is
  easy to understand, so its use is entirely optional.

This series aims to resolve tweag/sparkle#93.