### PR TITLE
Add new micro benchmarks to quantify cost of references.

### DIFF
--- a/jni/jni.cabal
+++ b/jni/jni.cabal
@@ -38,6 +38,7 @@ library
     choice >= 0.2.0,
     containers >=0.5,
     constraints >=0.8,
+    deepseq >= 1.4.2,
     inline-c >=0.5.6.1,
     singletons >= 2.0,
     thread-local-storage >=0.1

--- a/jni/src/Foreign/JNI/Types.hs
+++ b/jni/src/Foreign/JNI/Types.hs
@@ -66,6 +66,7 @@ module Foreign.JNI.Types
   , jniCtx
   ) where
 
+import Control.DeepSeq (NFData)
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Builder.Prim as Prim
@@ -107,19 +108,19 @@ import System.IO.Unsafe (unsafePerformIO)
 
 -- | A JVM instance.
 newtype JVM = JVM_ (Ptr JVM)
-  deriving (Eq, Show, Storable)
+  deriving (Eq, Show, Storable, NFData)
 
 -- | The thread-local JNI context. Do not share this object between threads.
 newtype JNIEnv = JNIEnv_ (Ptr JNIEnv)
-  deriving (Eq, Show, Storable)
+  deriving (Eq, Show, Storable, NFData)
 
 -- | A thread-local reference to a field of an object.
 newtype JFieldID = JFieldID_ (Ptr JFieldID)
-  deriving (Eq, Show, Storable)
+  deriving (Eq, Show, Storable, NFData)
 
 -- | A thread-local reference to a method of an object.
 newtype JMethodID = JMethodID_ (Ptr JMethodID)
-  deriving (Eq, Show, Storable)
+  deriving (Eq, Show, Storable, NFData)
 
 -- | Not part of the JNI. The kind of 'J' type indices. Useful to reflect the
 -- object's class at the type-level.

--- a/jvm/jvm.cabal
+++ b/jvm/jvm.cabal
@@ -60,6 +60,7 @@ benchmark micro-benchmarks
   build-depends:
     base >= 4.8 && < 5,
     criterion,
+    deepseq >= 1.4.2,
     jni,
     jvm,
     singletons


### PR DESCRIPTION
In partial fulfillment of #65, this PR adds code to quantify the cost
of creating new references to JVM objects. For comparison, we also
include microbenchmarks for creating foreign pointers directly, in two
different ways.

Includes a refactoring of benchmarks harness to make it possible to
run them independently.