### PR TITLE
Do away with ghc-heap-view dependency.

### DIFF
--- a/inline-java.cabal
+++ b/inline-java.cabal
@@ -26,6 +26,8 @@ library
   exposed-modules:
     Language.Java.Inline
     Language.Java.Inline.Cabal
+  other-modules:
+    Language.Java.Inline.Magic
   build-depends:
     -- Can't build at all with GHC < 8.0.2.
     base > 4.9.0.0 && < 5,
@@ -36,7 +38,7 @@ library
     directory >=1.2,
     distributed-closure >=0.3,
     filepath >= 1,
-    ghc-heap-view >= 0.5,
+    ghc-prim >= 0.5,
     inline-c >=0.5,
     jni >= 0.3,
     jvm >= 0.2,

--- a/src/Language/Java/Inline/Magic.hs
+++ b/src/Language/Java/Inline/Magic.hs
@@ -1,0 +1,74 @@
+-- | Internal module defining some magic, kept separate from the rest, that
+-- depends on compiler internals.
+
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE UnboxedTuples #-}
+
+module Language.Java.Inline.Magic
+  ( DotClass(className, classBytecode)
+  , mkDotClass
+  , isDotClassStaticKey
+  ) where
+
+import qualified Data.ByteString as BS
+import Foreign.Storable (sizeOf)
+import GHC.Exts (Int(..), Word(..), Word#)
+import GHC.Prim (indexWordArray#, sizeofByteArray#, unpackClosure#)
+import GHC.StaticPtr (StaticPtr, deRefStaticPtr)
+import qualified Language.Haskell.TH.Syntax as TH
+import Prelude hiding (words)
+
+-- | A wrapper for class bytecode. This datatype includes an unpacked
+-- fingerprint. This fingerprint is used by 'isDotClassStaticKey' to
+-- discriminate between static pointers to 'DotClass' values vs static pointers
+-- to other values just by inspecting whether the closure contains the magic
+-- values. Use 'mkDotClass' smart constructor to build.
+data DotClass = DotClass
+  { className :: String
+  , classBytecode :: BS.ByteString
+  , classMagicHigh :: Word#
+  , classMagicLow :: Word#
+  }
+
+mkDotClass
+  :: String -- ^ Class name
+  -> BS.ByteString -- ^ Class bytecode
+  -> DotClass
+mkDotClass className classBytecode =
+    let ![W# classMagicHigh, W# classMagicLow] = magic
+    in DotClass{..}
+
+instance TH.Lift DotClass where
+  lift DotClass{..} =
+      [| mkDotClass
+           $(TH.lift className)
+           (BS.pack $(TH.lift (BS.unpack classBytecode)))
+       |]
+
+-- | Two random numbers assumed to be unique.
+magic :: [Word]
+-- Explicit 'fromIntegral' to avoid literal overflow warnings on 32-bits
+-- architectures.
+magic =
+    [ fromIntegral (9312424290567649534 :: Integer)
+    , fromIntegral (8204450874354285209 :: Integer)
+    ]
+
+-- | Test whether the static key identifies a static pointer to a value of type
+-- 'DotClass'.
+isDotClassStaticKey :: StaticPtr a -> Bool
+isDotClassStaticKey sptr = words == magic
+  where
+    wordSize = sizeOf (undefined :: Word)
+    words =
+      let !x = deRefStaticPtr sptr in
+      case unpackClosure# x of
+        -- Inspect non-pointer members of the closure only. If magic isn't
+        -- unpacked properly, then we'll get false negatives.
+        (# _, _, nptrs #) ->
+          [ W# (indexWordArray# nptrs i)
+          | I# i <- [0 .. (I# (sizeofByteArray# nptrs) `div` wordSize) - 1]
+          ]


### PR DESCRIPTION
The static pointer table (SPT) in GHC currently lacks any typing
information. So to discriminate between static pointers that refer to
inline-java bytecode vs other random static pointers, we used
ghc-heap-view as a workaround.

It was a gross hack. It worked. But the cost of using this hammer is
that profiling builds were impossible.

This commit instead uses a much smaller hammer. Where ghc-heap-view
requires very intimate knowledge of much of GHC's memory layout, we
only use 'unpackClosure#'. Because we don't have the full power of
ghc-heap-view, we can't inspect the info table provided to us by this
primitive. But what we can do is inspect the environment of the
closure. If we find a pair of magic integers in there, then we assume
the static pointer does point to Java bytecode.