### PR TITLE
Add support for Android

### DIFF
--- a/jni/jni.cabal
+++ b/jni/jni.cabal
@@ -20,11 +20,17 @@ source-repository head
   location: https://github.com/tweag/inline-java
   subdir: jni
 
+flag ljvm
+  description: Needs -ljvm?
+  default: True
+  manual: True
+
 library
   hs-source-dirs: src
   c-sources: src/Foreign/JNI.c
   cc-options: -std=c11
-  extra-libraries: jvm
+  if flag(ljvm)
+    extra-libraries: jvm
   exposed-modules:
     Foreign.JNI
     Foreign.JNI.Types

--- a/jni/src/Foreign/JNI.cpphs
+++ b/jni/src/Foreign/JNI.cpphs
@@ -211,6 +211,7 @@ import Prelude hiding (String)
 C.context (C.baseCtx <> C.bsCtx <> jniCtx)
 
 C.include "<jni.h>"
+C.include "<stdio.h>"
 C.include "<errno.h>"
 C.include "<stdlib.h>"
 


### PR DESCRIPTION
When cross compiling to Android, the jvm is always present and there is no -ljvm.
Without stdio.h, `stderr` is implicit, which causes the generated `JNI.c` file to be
invalid.