### PR TITLE
Implement push and pop family of functions for managing local references.

### DIFF
--- a/jvm/jvm.cabal
+++ b/jvm/jvm.cabal
@@ -29,6 +29,7 @@ library
     constraints >= 0.8,
     choice >= 0.1,
     distributed-closure >=0.3,
+    exceptions >= 0.8,
     jni >= 0.3.0,
     singletons >= 2.0,
     template-haskell >= 2.10,


### PR DESCRIPTION
JNI Local references don't disappear until the control flow escapes
the current native call frame. This can be a very long time indeed, or
in fact never in the case of standalone apps. So we introduce `push`
to allocate a new block to store local references in. These references
can be discarded all at once when the control flow exits the scope of
the push. There is only one way to return a value out of the scope of
a push: by calling one of `popWithValue` or `popWithObject`. The
latter function is expected to be the common case. It's a thin wrapper
on top of `PopLocalFrame()` in the JNI, which only works for returning
objects.

There is nothing preventing the return of a local reference outside of
the scope in which it was allocated. But neither do any alternatives
that don't in one way or another link the type of references to the
type of the monad (like e.g. `STRef` in the `ST` monad). The design of
the API simply tries to make it unlikely.

`push` and `pop` cannot be added to tests yet, due to
https://github.com/hspec/hspec/pull/318 being a blocker. So we'll have
to keep those out for now.