### PR TITLE
Fix random lockups in the RW locks to finalize JNI.

### DIFF
--- a/jni/src/Foreign/JNI.cpphs
+++ b/jni/src/Foreign/JNI.cpphs
@@ -287,9 +287,8 @@ releaseReadLock (RWLock ref) = do
 acquireWriteLock :: RWLock -> IO ()
 acquireWriteLock (RWLock ref) = do
     mv <- newEmptyMVar
-    join $ atomicModifyIORef ref $ \case
-      (0, _) -> ((0, Writing mv),   return ())
-      st     -> (               st, takeMVar mv)
+    join $ atomicModifyIORef ref $ \(readers, _) ->
+      ((readers, Writing mv), when (readers > 0) (takeMVar mv))
 
 -- | This lock is used to avoid the JVM from dying before any finalizers
 -- deleting global references are finished.

--- a/jni/src/Foreign/JNI.cpphs
+++ b/jni/src/Foreign/JNI.cpphs
@@ -280,7 +280,7 @@ releaseReadLock (RWLock ref) = do
             \st@(readers, aim) -> ((readers - 1, aim), st)
     case st of
       -- Notify the writer if I'm the last reader.
-      (0, Writing mv) -> putMVar mv ()
+      (1, Writing mv) -> putMVar mv ()
       _               -> return ()
 
 -- | Waits until the current read locks are released and grants a write lock.


### PR DESCRIPTION
A writer could wait indefinitely if there were readers running at the time it requested the lock.