### PR TITLE
Rewrite environment checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
-* attachCurrentThreadAsDaemon, detachCurrentThread and asDaemonThread
-  are provided to have the application attach and detach threads.
+* attachCurrentThreadAsDaemon, detachCurrentThread and
+  runInAttachedThread are provided to have the application attach and
+  detach threads.
 
 ### Changed
 

--- a/jni/src/Foreign/JNI.cpphs
+++ b/jni/src/Foreign/JNI.cpphs
@@ -340,9 +340,11 @@ globalJVMLock = unsafePerformIO newRWLock
 {-# NOINLINE globalJVMLock #-}
 
 throwIfNotOK_ :: HasCallStack => IO Int32 -> IO ()
-throwIfNotOK_ m = m >>= \rc ->
-    when (rc /= [CU.pure| jint { JNI_OK } |]) $
-      throwIO $ JNIError (prettySrcLoc loc) rc
+throwIfNotOK_ m = m >>= \case
+  rc
+    | rc == [CU.pure| jint { JNI_OK } |] -> return ()
+    | rc == [CU.pure| jint { JNI_EDETACHED } |] -> throwIO ThreadNotAttached
+    | otherwise -> throwIO $ JNIError (prettySrcLoc loc) rc
   where
     (_, loc):_ = getCallStack callStack
 

--- a/jni/src/Foreign/JNI.cpphs
+++ b/jni/src/Foreign/JNI.cpphs
@@ -225,7 +225,8 @@ C.include "<stdio.h>"
 C.include "<errno.h>"
 C.include "<stdlib.h>"
 
--- A thread-local variable to store the JNI environment
+-- A thread-local variable to cache the JNI environment. Accessing this variable
+-- is faster than calling @jvm->GetEnv()@.
 $(C.verbatim "static __thread JNIEnv* jniEnv; ")
 
 -- | A JNI call may cause a (Java) exception to be raised. This module raises it
@@ -366,7 +367,6 @@ detachCurrentThread =
 -- then detaches the thread.
 --
 -- If the thread is already attached no attaching and detaching is performed.
---
 asDaemonThread :: IO a -> IO a
 asDaemonThread io = getJNIEnv >>= maybe
     (bracket_ attachCurrentThreadAsDaemon detachCurrentThread io)
@@ -393,32 +393,21 @@ jvm = unsafePerformIO $ alloca $ \pjvm -> alloca $ \pnum_jvms -> do
 -- | Yields the JNIEnv of the calling thread.
 --
 -- Yields @Nothing@ if the calling thread is not attached to the JVM.
-getJNIEnv :: IO (Maybe (Ptr JNIEnv))
-getJNIEnv = do
-    env0 <- [CU.exp| JNIEnv* { jniEnv } |]
-    if nullPtr /= env0 then
-      return $ Just env0
-    else do
-      rc <- [CU.exp| jint {
+getJNIEnv :: IO (Ptr JNIEnv)
+getJNIEnv = [CU.exp| JNIEnv* { jniEnv } |] >>= \case
+    env | env == nullPtr -> do
+      throwIfNotOK_
+        [CU.exp| jint {
           (*$(JavaVM* jvm))->GetEnv($(JavaVM* jvm), (void**)&jniEnv, JNI_VERSION_1_6)
         }|]
-      when (rc == [CU.pure| jint { JNI_EVERSION } |]) $
-        fail "GetEnv: Unsupported version."
-      if rc == [CU.pure| jint { JNI_EDETACHED } |] then
-        return Nothing
-      else do
-        when (rc /= jni_ok) $
-          throwIO $ JNIError "GetEnv" rc
-        env <- [CU.exp| JNIEnv* { jniEnv } |]
-        return $ Just env
+      [CU.exp| JNIEnv* { jniEnv } |]
+    env -> return env
 
 -- | Run an action against the appropriate 'JNIEnv'.
 --
 -- Each OS thread has its own 'JNIEnv', which this function gives access to.
---
--- TODO check whether this call is only safe from a (bound) thread.
 withJNIEnv :: (Ptr JNIEnv -> IO a) -> IO a
-withJNIEnv f = maybe (throwIO ThreadNotAttached) f =<< getJNIEnv
+withJNIEnv f = getJNIEnv >>= f
 
 useAsCStrings :: [ByteString] -> ([Ptr CChar] -> IO a) -> IO a
 useAsCStrings strs m =
@@ -434,7 +423,6 @@ newJVM options = JVM_ <$> do
         checkBoundness
         [C.block| JavaVM * {
           JavaVM *jvm;
-          JNIEnv *env;
           JavaVMInitArgs vm_args;
           JavaVMOption *options = malloc(sizeof(JavaVMOption) * $(int n));
           for(int i = 0; i < $(int n); i++)
@@ -443,7 +431,7 @@ newJVM options = JVM_ <$> do
           vm_args.nOptions = $(int n);
           vm_args.options = options;
           vm_args.ignoreUnrecognized = 0;
-          JNI_CreateJavaVM(&jvm, (void**)&env, &vm_args);
+          JNI_CreateJavaVM(&jvm, (void**)&jniEnv, &vm_args);
           free(options);
           return jvm; } |]
 
@@ -457,7 +445,10 @@ newJVM options = JVM_ <$> do
 destroyJVM :: JVM -> IO ()
 destroyJVM (JVM_ jvm) = do
     acquireWriteLock globalJVMLock
-    [C.block| void { (*$(JavaVM *jvm))->DestroyJavaVM($(JavaVM *jvm)); } |]
+    [C.block| void {
+        (*$(JavaVM *jvm))->DestroyJavaVM($(JavaVM *jvm));
+        jniEnv = NULL;
+    } |]
 
 -- | Create a new JVM, with the given arguments. Destroy it once the given
 -- action completes. /Can only be called once/. Best practice: use it to wrap

--- a/jni/src/Foreign/JNI.cpphs
+++ b/jni/src/Foreign/JNI.cpphs
@@ -210,11 +210,13 @@ import Foreign.Marshal.Array
 import Foreign.Ptr (Ptr, nullPtr)
 import Foreign.Storable (peek)
 import GHC.ForeignPtr (newConcForeignPtr)
+import GHC.Stack (HasCallStack, callStack, getCallStack, prettySrcLoc)
 import qualified Language.C.Inline as C
 import qualified Language.C.Inline.Unsafe as CU
 import System.IO (fixIO)
 import System.IO.Unsafe (unsafePerformIO)
 import Prelude hiding (String)
+import qualified Prelude
 
 C.context (C.baseCtx <> C.bsCtx <> jniCtx)
 
@@ -252,7 +254,7 @@ data ThreadNotBound = ThreadNotBound
   deriving (Exception, Show, Typeable)
 
 -- | Thrown when an JNI call is made from an unbound thread.
-data JNIError = JNIError JNI.String Int32
+data JNIError = JNIError Prelude.String Int32
   deriving (Show, Typeable)
 
 instance Exception JNIError
@@ -336,28 +338,29 @@ globalJVMLock :: RWLock
 globalJVMLock = unsafePerformIO newRWLock
 {-# NOINLINE globalJVMLock #-}
 
-jni_ok :: Int32
-jni_ok = [CU.pure| jint { JNI_OK } |]
-{-# NOINLINE jni_ok #-}
+throwIfNotOK_ :: HasCallStack => IO Int32 -> IO ()
+throwIfNotOK_ m = m >>= \rc ->
+    when (rc /= [CU.pure| jint { JNI_OK } |]) $
+      throwIO $ JNIError (prettySrcLoc loc) rc
+  where
+    (_, loc):_ = getCallStack callStack
 
 attachCurrentThreadAsDaemon :: IO ()
 attachCurrentThreadAsDaemon = do
-    rc <- [CU.exp| jint {
+    throwIfNotOK_
+      [CU.exp| jint {
         (*$(JavaVM* jvm))->AttachCurrentThreadAsDaemon($(JavaVM* jvm), &jniEnv, NULL)
       } |]
-    when (rc /= jni_ok) $
-      throwIO $ JNIError "attachCurrentThreadAsDaemon" rc
 
 detachCurrentThread :: IO ()
-detachCurrentThread = do
-    rc <- [CU.block| jint {
-        int rc = (*$(JavaVM* jvm))->DetachCurrentThread($(JavaVM* jvm));
-        if (rc == JNI_OK)
-          jniEnv = NULL;
-        return rc;
-      } |]
-    when (rc /= jni_ok) $
-      throwIO $ JNIError "detachCurrentThread" rc
+detachCurrentThread =
+    throwIfNotOK_
+    [CU.block| jint {
+      int rc = (*$(JavaVM* jvm))->DetachCurrentThread($(JavaVM* jvm));
+      if (rc == JNI_OK)
+        jniEnv = NULL;
+      return rc;
+    } |]
 
 -- | Attaches the calling thread to the JVM, runs the given IO action and
 -- then detaches the thread.
@@ -376,11 +379,10 @@ asDaemonThread io = getJNIEnv >>= maybe
 {-# NOINLINE jvm #-}
 jvm :: Ptr JVM
 jvm = unsafePerformIO $ alloca $ \pjvm -> alloca $ \pnum_jvms -> do
-    rc <- [CU.exp| jint {
+    throwIfNotOK_
+      [CU.exp| jint {
         JNI_GetCreatedJavaVMs($(JavaVM** pjvm), 1, $(jsize* pnum_jvms))
       }|]
-    when (rc /= jni_ok) $
-      throwIO $ JNIError "JNI_GetCreatedJavaVMs" rc
     num_jvms <- peek pnum_jvms
     when (num_jvms == 0) $
       fail "JNI_GetCreatedJavaVMs: No JVM has been initialized yet."

--- a/jni/src/Foreign/JNI.cpphs
+++ b/jni/src/Foreign/JNI.cpphs
@@ -179,12 +179,12 @@ module Foreign.JNI
     -- * Thread management
   , attachCurrentThreadAsDaemon
   , detachCurrentThread
-  , asDaemonThread
+  , runInAttachedThread
   ) where
 
 import Control.Concurrent (isCurrentThreadBound, rtsSupportsBoundThreads)
 import Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar, takeMVar)
-import Control.Exception (Exception, bracket, bracket_, finally, throwIO)
+import Control.Exception (Exception, bracket, bracket_, catch, finally, throwIO)
 import Control.Monad (join, unless, void, when)
 import Data.Choice
 import Data.Coerce
@@ -369,10 +369,16 @@ detachCurrentThread =
 -- then detaches the thread.
 --
 -- If the thread is already attached no attaching and detaching is performed.
-asDaemonThread :: IO a -> IO a
-asDaemonThread io = getJNIEnv >>= maybe
-    (bracket_ attachCurrentThreadAsDaemon detachCurrentThread io)
-    (const io)
+runInAttachedThread :: IO a -> IO a
+runInAttachedThread io = do
+    attached <-
+      catch (getJNIEnv >> return True) (\ThreadNotBound -> return False)
+    if attached
+    then io
+    else bracket_
+          attachCurrentThreadAsDaemon
+          detachCurrentThread
+          io
 
 -- | The current JVM
 --


### PR DESCRIPTION
I may have reviewed #86 too quickly before the merge. Looking at it
more closely, I don't understand why the current code actually works.
In particular, because jniEnv is not set during `newJVM`. This version
spells out the key invariant explicitly. All other functions maintain
this invariant, so `getJNIEnv` can be simpler.