### PR TITLE
Allows to convert `()` from java

### DIFF
--- a/jvm/src/Language/Java.hs
+++ b/jvm/src/Language/Java.hs
@@ -506,6 +506,8 @@ reflectMVector newfun fill mv = do
 #endif
 
 withStatic [d|
+  -- Ugly work around the fact that java has no equivalent of the 'unit' type:
+  -- We take an arbitrary serializable type to represent it.
   type instance Interp () = 'Class "java.lang.Short"
 
   instance Reify () where

--- a/jvm/src/Language/Java.hs
+++ b/jvm/src/Language/Java.hs
@@ -506,13 +506,13 @@ reflectMVector newfun fill mv = do
 #endif
 
 withStatic [d|
-  type instance Interp () = 'Class "java.lang.Object"
+  type instance Interp () = 'Class "java.lang.Short"
 
   instance Reify () where
     reify _ = return ()
 
   instance Reflect () where
-    reflect () = new []
+    reflect () = new [JShort 0]
 
   type instance Interp ByteString = 'Array ('Prim "byte")
 


### PR DESCRIPTION
Fixes a `java.io.NotSerializableException` when trying to convert back a java value to the `()` type