### PR TITLE
Make Coercible/Reify/Reflect derivable.

### DIFF
--- a/jvm-streaming/src/Language/Java/Streaming.hs
+++ b/jvm-streaming/src/Language/Java/Streaming.hs
@@ -139,7 +139,8 @@ newIterator stream = do
     return iterator
 
 withStatic [d|
-  type instance Interp (Stream (Of a) m r) = 'Iface "java.util.Iterator"
+  instance Interpretation (Stream (Of a) m r) where
+    type Interp (Stream (Of a) m r) = 'Iface "java.util.Iterator"
 
   instance Reify a => Reify (Stream (Of a) IO ()) where
     reify itLocal = do

--- a/src/Language/Java/Inline/Magic.hsc
+++ b/src/Language/Java/Inline/Magic.hsc
@@ -5,6 +5,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
@@ -37,7 +38,7 @@ import Foreign.Storable
 import GHC.Stack (HasCallStack, withFrozenCallStack)
 import GHC.TypeLits (Nat, Symbol)
 import qualified Language.Haskell.TH.Syntax as TH
-import Language.Java (Coercible)
+import Language.Java (Coercible, Ty, JType)
 
 #include "bctable.h"
 
@@ -96,7 +97,7 @@ qqMarker
      (line :: Nat)       -- line number of the quasiquotation
      args_tuple          -- uncoerced argument types
      b.                  -- uncoerced result type
-     (Coercibles args_tuple args_tys, Coercible b tyres, HasCallStack)
+     (CoercibleRels args_tuple args_tys, CoercibleRel b tyres, HasCallStack)
   => Proxy input
   -> Proxy mname
   -> Proxy antiqs
@@ -110,6 +111,9 @@ qqMarker _ _ _ _ _ = withFrozenCallStack $
       "Please pass -fplugin=Language.Java.Inline.Plugin"
       ++ " to ghc when building this module."
 
-class Coercibles xs (tys :: k) | xs -> tys
-instance Coercibles () ()
-instance (Coercible x ty, Coercibles xs tys) => Coercibles (x, xs) '(ty, tys)
+class CoercibleRel a (ty :: JType) | a -> ty
+instance (ty ~ Ty a, Coercible a) => CoercibleRel a ty
+
+class CoercibleRels xs (tys :: k) | xs -> tys
+instance CoercibleRels () ()
+instance (CoercibleRel x ty, CoercibleRels xs tys) => CoercibleRels (x, xs) '(ty, tys)

--- a/src/Language/Java/Inline/Magic.hsc
+++ b/src/Language/Java/Inline/Magic.hsc
@@ -38,7 +38,7 @@ import Foreign.Storable
 import GHC.Stack (HasCallStack, withFrozenCallStack)
 import GHC.TypeLits (Nat, Symbol)
 import qualified Language.Haskell.TH.Syntax as TH
-import Language.Java (Coercible, Ty, JType)
+import Language.Java (Coercible, Ty)
 
 #include "bctable.h"
 
@@ -97,7 +97,7 @@ qqMarker
      (line :: Nat)       -- line number of the quasiquotation
      args_tuple          -- uncoerced argument types
      b.                  -- uncoerced result type
-     (CoercibleRels args_tuple args_tys, CoercibleRel b tyres, HasCallStack)
+     (tyres ~ Ty b, Coercibles args_tuple args_tys, Coercible b, HasCallStack)
   => Proxy input
   -> Proxy mname
   -> Proxy antiqs
@@ -111,9 +111,6 @@ qqMarker _ _ _ _ _ = withFrozenCallStack $
       "Please pass -fplugin=Language.Java.Inline.Plugin"
       ++ " to ghc when building this module."
 
-class CoercibleRel a (ty :: JType) | a -> ty
-instance (ty ~ Ty a, Coercible a) => CoercibleRel a ty
-
-class CoercibleRels xs (tys :: k) | xs -> tys
-instance CoercibleRels () ()
-instance (CoercibleRel x ty, CoercibleRels xs tys) => CoercibleRels (x, xs) '(ty, tys)
+class Coercibles xs (tys :: k) | xs -> tys
+instance Coercibles () ()
+instance (ty ~ Ty x, Coercible x, Coercibles xs tys) => Coercibles (x, xs) '(ty, tys)

--- a/src/Language/Java/Inline/Plugin.hs
+++ b/src/Language/Java/Inline/Plugin.hs
@@ -356,14 +356,14 @@ collectQQMarkers qqMarkerName p0 = do
 
     expMarkers :: CoreExpr -> QQJavaM CoreExpr
     expMarkers (App (App (App (App (App (App (App (App (App (App (App (App (App
-                 (App (App (App (App (App (App (Var fid) _)
+                 (App (App (App (App (App (App (App (Var fid) _)
                  (Type (parseArgTys -> Just tyargs)))
                  (Type tyres))
                  (Type (LitTy (StrTyLit fs_input))))
                  (Type (LitTy (StrTyLit fs_mname))))
                  (Type (LitTy (StrTyLit fs_antiqs))))
                  (Type (LitTy (NumTyLit lineNumber))))
-                 _) _) _) _) _) _) _) _) _) _) _)
+                 _) _) _) _) _) _) _) _) _) _) _) _)
                  e
                )
         | qqMarkerName == idName fid = do

--- a/src/Language/Java/Inline/Plugin.hs
+++ b/src/Language/Java/Inline/Plugin.hs
@@ -148,9 +148,9 @@ buildJava guts qqOccs jimports = do
                     ]
           | JavaImport jimp n <- jimports
           ]
+    p_fam_env <- getPackageFamInstEnv
+    let fam_envs = (p_fam_env, mg_fam_inst_env guts)
     methods <- forM qqOccs $ \QQOcc {..} -> do
-      p_fam_env <- getPackageFamInstEnv
-      let fam_envs = (p_fam_env, mg_fam_inst_env guts)
       let (_, normty) = normaliseType fam_envs Nominal (expandTypeSynonyms qqOccResTy)
       jTypeNames <- findJTypeNames
       resty <- case toJavaType jTypeNames normty of


### PR DESCRIPTION
With the changes in this PR, it is now possible to:

```haskell
newtype T = T (J ('Class ...))
  deriving (Coercible, Interpretation, Reify, Reflect)
```

This is important, because what we're also doing in this PR is
dropping all invariants about how newtype wrapped stuff should *not*
be reifiable/reflectable. This means we'll want most newtype wrapped
references to be reifiable/reflectable. That's only really viable if
we can keep the boilerplate to a minimum, in particular be making
these instances derivable.