### PR TITLE
Add Reflect/Reify for Vector Double

### DIFF
--- a/jvm/CHANGELOG.md
+++ b/jvm/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Next release
 
+### Added
+
+* `Reify`/`Reflect` instances for `Vector/IOVector Double`.
+
 ### Changed
 
 * The `Coercible` type class now also takes a single parameter, like

--- a/jvm/src/Language/Java.hs
+++ b/jvm/src/Language/Java.hs
@@ -704,15 +704,6 @@ withStatic [d|
   instance Reflect (IOVector Int32) where
     reflect = reflectMVector (newIntArray) (setIntArrayRegion)
 
-  instance Interpretation (Vector Int32) where
-    type Interp (Vector Int32) = 'Array ('Prim "int")
-
-  instance Reify (Vector Int32) where
-    reify = Vector.freeze <=< reify
-
-  instance Reflect (Vector Int32) where
-    reflect = reflect <=< Vector.thaw
-
   instance Interpretation (IOVector Double) where
     type Interp (IOVector Double) = 'Array ('Prim "double")
 
@@ -722,13 +713,13 @@ withStatic [d|
   instance Reflect (IOVector Double) where
     reflect = reflectMVector (newDoubleArray) (setDoubleArrayRegion)
 
-  instance Interpretation (Vector Double) where
-    type Interp (Vector Double) = 'Array ('Prim "double")
+  instance Interpretation (IOVector a) => Interpretation (Vector a) where
+    type Interp (Vector a) = Interp (IOVector a)
 
-  instance Reify (Vector Double) where
+  instance (Storable a, Reify (IOVector a)) => Reify (Vector a) where
     reify = Vector.freeze <=< reify
 
-  instance Reflect (Vector Double) where
+  instance (Storable a, Reflect (IOVector a)) => Reflect (Vector a) where
     reflect = reflect <=< Vector.thaw
 #endif
   instance Interpretation a => Interpretation [a] where

--- a/jvm/src/Language/Java.hs
+++ b/jvm/src/Language/Java.hs
@@ -712,6 +712,24 @@ withStatic [d|
 
   instance Reflect (Vector Int32) where
     reflect = reflect <=< Vector.thaw
+
+  instance Interpretation (IOVector Double) where
+    type Interp (IOVector Double) = 'Array ('Prim "double")
+
+  instance Reify (IOVector Double) where
+    reify = reifyMVector (getDoubleArrayElements) (releaseDoubleArrayElements)
+
+  instance Reflect (IOVector Double) where
+    reflect = reflectMVector (newDoubleArray) (setDoubleArrayRegion)
+
+  instance Interpretation (Vector Double) where
+    type Interp (Vector Double) = 'Array ('Prim "double")
+
+  instance Reify (Vector Double) where
+    reify = Vector.freeze <=< reify
+
+  instance Reflect (Vector Double) where
+    reflect = reflect <=< Vector.thaw
 #endif
   instance Interpretation a => Interpretation [a] where
     type Interp [a] = 'Array (Interp a)


### PR DESCRIPTION
`Vector Double` reflects to/reifies from `double[]`

I had to add these in order to implement `randomSplit` which takes `double[]` as an argument (not `Double[]`): https://github.com/MailOnline/sparkle/blob/9c3788a28bfcc8d6c9ed4a87b329aea2f48ff57f/src/Control/Distributed/Spark/RDD.hs#L230

I'd be interested to know if there's a better way to achieve this ^