### PR TITLE
Replace .cpphs suffix with -pgmP directive.

### DIFF
--- a/jni/src/Foreign/JNI.hs
+++ b/jni/src/Foreign/JNI.hs
@@ -15,6 +15,7 @@
 -- "Foreign.JNI.String".
 
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE ExplicitNamespaces #-}


### PR DESCRIPTION
This avoids requiring that the build system knows about cpphs.