### PR TITLE
Look for cbits/bctable.h instead of assuming the build directory.

### DIFF
--- a/src/Language/Java/Inline/Plugin.hs
+++ b/src/Language/Java/Inline/Plugin.hs
@@ -36,7 +36,7 @@ import NameCache (nsNames)
 import TyCoRep
 import TysWiredIn (nilDataConName, consDataConName)
 import System.Directory (listDirectory)
-import System.FilePath ((</>), (<.>))
+import System.FilePath ((</>), (<.>), takeDirectory)
 import System.IO (withFile, IOMode(WriteMode), hPutStrLn, stderr)
 import System.IO.Temp (withSystemTempDirectory)
 import System.Process (callProcess)
@@ -93,7 +93,9 @@ plugin = defaultPlugin
     -- command line without saying -package inline-java.
     bctable_header :: String
     bctable_header = $(do
-        let f = "cbits/bctable.h"
+        loc <- TH.location
+        let root = iterate takeDirectory (TH.loc_filename loc) !! 5
+            f = root </> "cbits/bctable.h"
         TH.addDependentFile f
         TH.lift =<< TH.runIO (readFile f)
       )


### PR DESCRIPTION
Fixes #101.

------------

This is necessary for things like bazel where the file at build time might actually live in something like `external/inline_java/cbits/bctable.h` if inline-java is being built as a dependency rather than directly as is the case with `sparkle` for example.