### PR TITLE
Bazel build files for inline-java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .gradle
 build/
 jni/src/Foreign/JNI.c
+bazel-*

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,60 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_test",
+  "haskell_library",
+  "haskell_toolchain",
+)
+
+haskell_toolchain(
+  name = "inline-java-toolchain",
+  version = "8.2.2",
+  tools = "@inline-java-toolchain//:bin",
+)
+
+haskell_library(
+  name = "inline-java",
+  src_strip_prefix = "src",
+  srcs = glob(['src/**/*.hs', 'src/**/*.hsc']),
+  deps = [
+    "//jni",
+    "//jvm"
+  ],
+  external_deps = [
+    "cbits/bctable.h"
+  ],
+  c_sources = ["cbits/bctable.c"],
+  prebuilt_dependencies = [
+    "base",
+    "bytestring",
+    "Cabal",
+    "directory",
+    "filepath",
+    "filemanip",
+    "ghc",
+    "language-java",
+    "mtl",
+    "process",
+    "text",
+    "template-haskell",
+    "temporary"
+  ],
+)
+
+haskell_test(
+  name = "spec",
+  src_strip_prefix = "tests",
+  srcs = glob(["tests/**/*.hs"]),
+  deps = [
+    "//jni",
+    "//jvm",
+    ":inline-java"
+  ],
+  prebuilt_dependencies = [
+    "base",
+    "hspec",
+    "text",
+  ],
+  size = "small",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,6 +26,7 @@ load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl",
 
 nixpkgs_git_repository(
   name = "nixpkgs",
+  # Keep consistent with ./nixpkgs.nix.
   revision = "4026ea9c8afd09b60896b861a04cc5748fdcdfb4",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-workspace(name = "inline_java")
+workspace(name = "io_tweag_inline_java")
 
 http_archive(
     name = "io_tweag_rules_haskell",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,122 @@
+workspace(name = "inline_java")
+
+http_archive(
+    name = "io_tweag_rules_haskell",
+    strip_prefix = "rules_haskell-a1f5b6a21e6cc568ef476b8c63f4c1c60ffc5a03",
+    urls = ["https://github.com/tweag/rules_haskell/archive/a1f5b6a21e6cc568ef476b8c63f4c1c60ffc5a03.tar.gz"]
+)
+
+local_repository(
+  name = "io_tweag_rules_haskell",
+  path = "/home/shana/programming/rules_haskell",
+)
+
+http_archive(
+    name = "io_tweag_rules_nixpkgs",
+    strip_prefix = "rules_nixpkgs-53700e429928530f1566cfff3ec00283a123f17f",
+    urls = ["https://github.com/tweag/rules_nixpkgs/archive/53700e429928530f1566cfff3ec00283a123f17f.tar.gz"],
+)
+
+# Required due to rules_haskell use of skylib.
+http_archive(
+  name = "bazel_skylib",
+  strip_prefix = "bazel-skylib-0.2.0",
+  urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.2.0.tar.gz"]
+)
+
+load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl",
+  "nixpkgs_git_repository",
+  "nixpkgs_package",
+)
+
+nixpkgs_git_repository(
+  name = "nixpkgs",
+  revision = "4026ea9c8afd09b60896b861a04cc5748fdcdfb4",
+)
+
+jni_prebuilt = [
+  "base",
+  "bytestring",
+  "choice",
+  "containers",
+  "constraints",
+  "deepseq",
+  "inline-c",
+  "singletons"
+]
+
+jvm_prebuilt = [
+  "base",
+  "bytestring",
+  "constraints",
+  "choice",
+  "distributed-closure",
+  "exceptions",
+  "singletons",
+  "text",
+  "vector",
+]
+
+inline_java_prebuilt = [
+  "base",
+  "bytestring",
+  "Cabal",
+  "directory",
+  "filepath",
+  "filemanip",
+  "ghc",
+  "language-java",
+  "mtl",
+  "process",
+  "text",
+  "template-haskell",
+  "temporary",
+  "hspec",
+]
+
+jvm_streaming_prebuilt = [
+  "base",
+  "distributed-closure",
+  "singletons",
+  "streaming",
+  "hspec",
+]
+
+nixpkgs_package(
+  name = "inline-java-toolchain",
+  repository = "@nixpkgs",
+  nix_file_content = """
+let pkgs = import <nixpkgs> {{}};
+in pkgs.buildEnv {{
+  name = "inline-java-toolchain";
+  paths = with pkgs; [
+    (haskell.packages.ghc822.ghcWithPackages (p: with p; [{0}]))
+    openjdk
+  ];
+}}
+""".format(
+    " ".join(depset(jni_prebuilt + jvm_prebuilt + inline_java_prebuilt + jvm_streaming_prebuilt).to_list())
+))
+
+nixpkgs_package(
+  name = "openjdk",
+  repository = "@nixpkgs",
+  build_file_content = """
+filegroup (
+  name = "lib",
+  srcs = ["nix/lib/openjdk/jre/lib/amd64/server/libjvm.so"],
+  visibility = ["//visibility:public"],
+)
+filegroup (
+  name = "jni_header",
+  srcs = ["nix/include/jni.h"],
+  visibility = ["//visibility:public"],
+)
+filegroup (
+  name = "jni_md_header",
+  srcs = ["nix/include/jni_md.h"],
+  visibility = ["//visibility:public"],
+)"""
+)
+
+register_toolchains("//:inline-java-toolchain")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,20 +1,15 @@
 workspace(name = "io_tweag_inline_java")
 
 http_archive(
-    name = "io_tweag_rules_haskell",
-    strip_prefix = "rules_haskell-a1f5b6a21e6cc568ef476b8c63f4c1c60ffc5a03",
-    urls = ["https://github.com/tweag/rules_haskell/archive/a1f5b6a21e6cc568ef476b8c63f4c1c60ffc5a03.tar.gz"]
-)
-
-local_repository(
   name = "io_tweag_rules_haskell",
-  path = "/home/shana/programming/rules_haskell",
+  strip_prefix = "rules_haskell-8120ec9c600bc70a1268c05892f2f267248eb560",
+  urls = ["https://github.com/tweag/rules_haskell/archive/8120ec9c600bc70a1268c05892f2f267248eb560.tar.gz"]
 )
 
 http_archive(
-    name = "io_tweag_rules_nixpkgs",
-    strip_prefix = "rules_nixpkgs-53700e429928530f1566cfff3ec00283a123f17f",
-    urls = ["https://github.com/tweag/rules_nixpkgs/archive/53700e429928530f1566cfff3ec00283a123f17f.tar.gz"],
+  name = "io_tweag_rules_nixpkgs",
+  strip_prefix = "rules_nixpkgs-53700e429928530f1566cfff3ec00283a123f17f",
+  urls = ["https://github.com/tweag/rules_nixpkgs/archive/53700e429928530f1566cfff3ec00283a123f17f.tar.gz"],
 )
 
 # Required due to rules_haskell use of skylib.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,52 +29,31 @@ nixpkgs_git_repository(
   revision = "4026ea9c8afd09b60896b861a04cc5748fdcdfb4",
 )
 
-jni_prebuilt = [
+prebuilt_packages = [
+  "Cabal",
   "base",
   "bytestring",
   "choice",
+  "constraints",
   "containers",
-  "constraints",
   "deepseq",
-  "inline-c",
-  "singletons"
-]
-
-jvm_prebuilt = [
-  "base",
-  "bytestring",
-  "constraints",
-  "choice",
+  "directory",
   "distributed-closure",
   "exceptions",
-  "singletons",
-  "text",
-  "vector",
-]
-
-inline_java_prebuilt = [
-  "base",
-  "bytestring",
-  "Cabal",
-  "directory",
-  "filepath",
   "filemanip",
+  "filepath",
   "ghc",
+  "hspec",
+  "inline-c",
   "language-java",
   "mtl",
   "process",
-  "text",
-  "template-haskell",
-  "temporary",
-  "hspec",
-]
-
-jvm_streaming_prebuilt = [
-  "base",
-  "distributed-closure",
   "singletons",
   "streaming",
-  "hspec",
+  "template-haskell",
+  "temporary",
+  "text",
+  "vector",
 ]
 
 nixpkgs_package(
@@ -89,9 +68,7 @@ in pkgs.buildEnv {{
     openjdk
   ];
 }}
-""".format(
-    " ".join(depset(jni_prebuilt + jvm_prebuilt + inline_java_prebuilt + jvm_streaming_prebuilt).to_list())
-))
+""".format(" ".join(prebuilt_packages)))
 
 nixpkgs_package(
   name = "openjdk",

--- a/jni/BUILD
+++ b/jni/BUILD
@@ -1,0 +1,38 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_import",
+  "haskell_library",
+)
+
+haskell_import(
+  name = "openjdk",
+  shared_library = "@openjdk//:lib"
+)
+
+haskell_library(
+  name = "jni",
+  src_strip_prefix = "src",
+  srcs = glob(['src/**/*.hs', 'src/**/*.hsc']),
+  c_sources = glob(['src/**/*.c']),
+  c_options = ["-std=c11"],
+  deps = [
+    ":openjdk"
+  ],
+  # https://stackoverflow.com/questions/46160790/bazel-for-jni-jni-h-file-not-found
+  external_deps = [
+    "@openjdk//:jni_header",
+    "@openjdk//:jni_md_header",
+  ],
+  prebuilt_dependencies = [
+    "base",
+    "bytestring",
+    "choice",
+    "containers",
+    "constraints",
+    "deepseq",
+    "inline-c",
+    "singletons",
+  ],
+)

--- a/jvm-streaming/BUILD
+++ b/jvm-streaming/BUILD
@@ -1,0 +1,41 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_test",
+  "haskell_library",
+)
+
+haskell_library(
+  name = "jvm-streaming",
+  src_strip_prefix = "src",
+  srcs = glob(['src/**/*.hs']),
+  deps = [
+    "//jni",
+    "//:inline-java",
+    "//jvm",
+  ],
+  prebuilt_dependencies = [
+    "base",
+    "distributed-closure",
+    "singletons",
+    "streaming",
+  ],
+)
+
+haskell_test(
+  name = "spec",
+  src_strip_prefix = "tests",
+  srcs = glob(['tests/**/*.hs']),
+  deps = [
+    ":jvm-streaming",
+    "//jvm",
+    "//:inline-java",
+  ],
+  prebuilt_dependencies = [
+    "base",
+    "hspec",
+    "streaming",
+  ],
+  size = "small",
+)

--- a/jvm/BUILD
+++ b/jvm/BUILD
@@ -1,0 +1,26 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_library",
+)
+
+haskell_library(
+  name = "jvm",
+  src_strip_prefix = "src",
+  srcs = glob(['src/**/*.hs']),
+  deps = [
+    "//jni",
+  ],
+  prebuilt_dependencies = [
+    "base",
+    "bytestring",
+    "constraints",
+    "choice",
+    "distributed-closure",
+    "exceptions",
+    "singletons",
+    "text",
+    "vector",
+  ],
+)

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,1 +1,1 @@
-import (fetchTarball "https://github.com/nixos/nixpkgs/archive/1354099daf98b7a1f79e6c41ce6bfda5c40177ae.tar.gz")
+import (fetchTarball "https://github.com/nixos/nixpkgs/archive/4026ea9c8afd09b60896b861a04cc5748fdcdfb4.tar.gz")

--- a/src/Language/Java/Inline/Magic.hsc
+++ b/src/Language/Java/Inline/Magic.hsc
@@ -16,7 +16,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -ddump-ds #-}
 
 module Language.Java.Inline.Magic
   ( DotClass(..)


### PR DESCRIPTION
This is a collection of build files that work with the given WORKSPACE
file. This should allow the user to run `bazel test //...` which will
build run all tests in `inline-java`: as of time of writing, this is
spec tests in `inline-java` and `jvm-streaming`.

* We're repeating ourselves a lot w.r.t. prebuilt dependencies. We
  need to have all the packages available to GHC at WORKSPACE level
  then we also need to know them at BUILD level. We can't just define
  them in WORKSPACE and refer to them from BUILD as WORKSPACE only
  works in current project: if user wants to use inline-java from
  another project, the WORKSPACE file here is irrelevant: indeed
  they'll have to define all these things in their own WORKSPACE.

-----------------------------
Old PR description below. Note that nearly all points there have now been resolved due to better `rules_haskell`/`rules_nixpkgs` 🎊 
-----------------------------

This is a collection of build files that work with the given WORKSPACE
file. This should allow the user to run `bazel run //:spec` which will
build inline-java and run the spec tests.

* I'm using GHC 8.0.2 as I was unable to quickly find working 8.2.2
  set.
* We're taking open JDK header files from bazel but the libraries from
  nix. Neither exposes both:
  https://github.com/tweag/rules_nixpkgs/issues/9
* We're repeating ourselves a lot w.r.t. prebuilt dependencies. We
  need to have all the packages available to GHC at WORKSPACE level
  then we also need to know them at BUILD level. We can't just define
  them in WORKSPACE and refer to them from BUILD as WORKSPACE only
  works in current project: if user wants to use inline-java from
  another project, the WORKSPACE file here is irrelevant: indeed
  they'll have to define all these things in their own WORKSPACE.
* `rules_nixpkgs` commit points at a temporary branch which includes
  changes from two outstanding PRs, both of which are needed to build
  inline-java
* `spec` target would be better as some `haskell_test` once that
  exists
* We're giving too many shared openjdk libs during build: we only need
  libjvm.so and maybe libjni.so but we don't have granular control
  over the filegroup so we end up using every shared lib in openjdk
  package which is not ideal.