### PR TITLE
Cast jniEnv ref to void**

### DIFF
--- a/jni/src/Foreign/JNI.hs
+++ b/jni/src/Foreign/JNI.hs
@@ -353,7 +353,7 @@ attachCurrentThreadAsDaemon :: IO ()
 attachCurrentThreadAsDaemon = do
     throwIfNotOK_
       [CU.exp| jint {
-        (*$(JavaVM* jvm))->AttachCurrentThreadAsDaemon($(JavaVM* jvm), &jniEnv, NULL)
+        (*$(JavaVM* jvm))->AttachCurrentThreadAsDaemon($(JavaVM* jvm), (void**)&jniEnv, NULL)
       } |]
 
 detachCurrentThread :: IO ()


### PR DESCRIPTION
This is what JNI expects. Without this we get errors during build
though these do seem non-fatal. This cast is already performed just
few lines down.

```
2017-12-29 16:53:45.011881: [info] /nix/store/bw5qbjqf3mqis99kyzz973q4djdxv9ba-ghc-8.0.2/bin/ghc -c -fPIC -odir .stack-work/dist/x86_64-linux-nix/Cabal-1.24.2.0/build -I.stack-work/dist/x86_64-linux-nix/Cabal-1.24.2.0/build/autogen -I.stack-work/dist/x86_64-linux-nix/Cabal-1.24.2.0/build -I/nix/store/347h96g34wg35l2kv8fbn73i4m40gzdc-openjdk-8u152b16/include -I/nix/store/44dk7fyy724x2vlm4xvcm8l2wcm0l7iy-git-2.15.1/include -I/nix/store/fj4shhg1mkpqlh7py00zfccvw9yh6snh-gradle-4.4/include -optc-O2 '-optc-std=c11' -hide-all-packages -no-user-package-db -package-db /home/shana/.stack/snapshots/x86_64-linux-nix/lts-9.18/8.0.2/pkgdb -package-db /home/shana/programming/inline-java/.stack-work/install/x86_64-linux-nix/lts-9.18/8.0.2/pkgdb -package-db .stack-work/dist/x86_64-linux-nix/Cabal-1.24.2.0/package.conf.inplace -package-id base-4.9.1.0 -package-id bytestring-0.10.8.1 -package-id choice-0.2.2-eD56hnOJhE3l9GMwUZbN3 -package-id constraints-0.9.1-5mmQfXdFR8IpJ6JZxzjTB -package-id containers-0.5.7.1 -package-id deepseq-1.4.2.0 -package-id inline-c-0.5.6.1-FYk5ZUKA3nE7sbTl75bdC -package-id singletons-2.2-F6aalBFPo1F9ebvy1Wkuj3 src/Foreign/JNI.c -ddump-hi -ddump-to-file
@(Stack/Build/Execute.hs:1126:67)
2017-12-29 16:53:45.179789: [warn] src/Foreign/JNI.c: In function ‘inline_c_Foreign_JNI_5_11ef4c1fdcde263336fdb13b08ff0f2e19d0df2f’:
@(Stack/Build/Execute.hs:1126:67)
2017-12-29 16:53:45.179878: [warn]
@(Stack/Build/Execute.hs:1126:67)
2017-12-29 16:53:45.179959: [warn] /home/shana/programming/inline-java/jni/src/Foreign/JNI.c:39:72: error:
@(Stack/Build/Execute.hs:1126:67)
2017-12-29 16:53:45.180005: [warn]      warning: passing argument 2 of ‘(*jvm_inline_c_0)->AttachCurrentThreadAsDaemon’ from incompatible pointer type [-Wincompatible-pointer-types]
@(Stack/Build/Execute.hs:1126:67)
2017-12-29 16:53:45.180037: [warn]              (*jvm_inline_c_0)->AttachCurrentThreadAsDaemon(jvm_inline_c_1, &jniEnv, NULL)
@(Stack/Build/Execute.hs:1126:67)
2017-12-29 16:53:45.180063: [warn]                                                                             ^
@(Stack/Build/Execute.hs:1126:67)
2017-12-29 16:53:45.180089: [warn]
@(Stack/Build/Execute.hs:1126:67)
2017-12-29 16:53:45.180184: [warn] /home/shana/programming/inline-java/jni/src/Foreign/JNI.c:39:72: error:
@(Stack/Build/Execute.hs:1126:67)
2017-12-29 16:53:45.180217: [warn]      note: expected ‘void **’ but argument is of type ‘const struct JNINativeInterface_ ***’
@(Stack/Build/Execute.hs:1126:67)
2017-12-29 16:53:45.201118: [info] /nix/store/bw5qbjqf3mqis99kyzz973q4djdxv9ba-ghc-8.0.2/bin/ghc -c -dynamic -fPIC -osuf dyn_o -odir .stack-work/dist/x86_64-linux-nix/Cabal-1.24.2.0/build -I.stack-work/dist/x86_64-linux-nix/Cabal-1.24.2.0/build/autogen -I.stack-work/dist/x86_64-linux-nix/Cabal-1.24.2.0/build -I/nix/store/347h96g34wg35l2kv8fbn73i4m40gzdc-openjdk-8u152b16/include -I/nix/store/44dk7fyy724x2vlm4xvcm8l2wcm0l7iy-git-2.15.1/include -I/nix/store/fj4shhg1mkpqlh7py00zfccvw9yh6snh-gradle-4.4/include -optc-O2 '-optc-std=c11' -hide-all-packages -no-user-package-db -package-db /home/shana/.stack/snapshots/x86_64-linux-nix/lts-9.18/8.0.2/pkgdb -package-db /home/shana/programming/inline-java/.stack-work/install/x86_64-linux-nix/lts-9.18/8.0.2/pkgdb -package-db .stack-work/dist/x86_64-linux-nix/Cabal-1.24.2.0/package.conf.inplace -package-id base-4.9.1.0 -package-id bytestring-0.10.8.1 -package-id choice-0.2.2-eD56hnOJhE3l9GMwUZbN3 -package-id constraints-0.9.1-5mmQfXdFR8IpJ6JZxzjTB -package-id containers-0.5.7.1 -package-id deepseq-1.4.2.0 -package-id inline-c-0.5.6.1-FYk5ZUKA3nE7sbTl75bdC -package-id singletons-2.2-F6aalBFPo1F9ebvy1Wkuj3 src/Foreign/JNI.c -ddump-hi -ddump-to-file
@(Stack/Build/Execute.hs:1126:67)
2017-12-29 16:53:45.370052: [warn] src/Foreign/JNI.c: In function ‘inline_c_Foreign_JNI_5_11ef4c1fdcde263336fdb13b08ff0f2e19d0df2f’:
@(Stack/Build/Execute.hs:1126:67)
2017-12-29 16:53:45.370138: [warn]
@(Stack/Build/Execute.hs:1126:67)
2017-12-29 16:53:45.370232: [warn] /home/shana/programming/inline-java/jni/src/Foreign/JNI.c:39:72: error:
@(Stack/Build/Execute.hs:1126:67)
2017-12-29 16:53:45.370268: [warn]      warning: passing argument 2 of ‘(*jvm_inline_c_0)->AttachCurrentThreadAsDaemon’ from incompatible pointer type [-Wincompatible-pointer-types]
@(Stack/Build/Execute.hs:1126:67)
2017-12-29 16:53:45.370329: [warn]              (*jvm_inline_c_0)->AttachCurrentThreadAsDaemon(jvm_inline_c_1, &jniEnv, NULL)
@(Stack/Build/Execute.hs:1126:67)
2017-12-29 16:53:45.370360: [warn]                                                                             ^
@(Stack/Build/Execute.hs:1126:67)
2017-12-29 16:53:45.370386: [warn]
@(Stack/Build/Execute.hs:1126:67)
2017-12-29 16:53:45.370454: [warn] /home/shana/programming/inline-java/jni/src/Foreign/JNI.c:39:72: error:
@(Stack/Build/Execute.hs:1126:67)
2017-12-29 16:53:45.370488: [warn]      note: expected ‘void **’ but argument is of type ‘const struct JNINativeInterface_ ***’
@(Stack/Build/Execute.hs:1126:67)
2017-12-29 16:53:45.394553: [info] Linking...
```