### PR TITLE
Workaround Gradle sometimes trashing output in recent versions.

### DIFF
--- a/src/Language/Java/Inline/Cabal.hs
+++ b/src/Language/Java/Inline/Cabal.hs
@@ -71,8 +71,9 @@ getGradleClasspath parentBuildfile = do
           , "task classpath { doLast { println sourceSets.main.compileClasspath.getAsPath() } }"
           ]
       readProcess "gradle" ["-q", "-b", buildfile, "classpath"] ""
-        -- trim trailing newlines
-        >>= return . concat . lines
+        -- Get the last line of output. Sometimes Gradle prepends garbage to the
+        -- output despite the -q flag.
+        >>= return . last . lines
 
 -- | Prepends the @CLASSPATH@ with the classpath from a Gradle build
 -- configuration.


### PR DESCRIPTION
Newer versions of Gradle think it's a great idea to output a summary
of the release notes even when the `-q` flag for "quiet!" is passed,
but only on the first run. This trashes the output that we're
capturing to get at the CLASSPATH. So as a workaround, we make sure to
only capture the *last* line of output from `gradle build -q`.