### PR TITLE
Update the example in jvm/README.md

### DIFF
--- a/jvm/README.md
+++ b/jvm/README.md
@@ -16,15 +16,15 @@ Graphical Hello World using Java Swing:
 
 ```Haskell
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 import Data.Text (Text)
 import Language.Java
 
 newtype JOptionPane = JOptionPane (J ('Class "javax.swing.JOptionPane"))
-instance Coercible JOptionPane ('Class "javax.swing.JOptionPane")
+  deriving Coercible
 
 main :: IO ()
 main = withJVM [] $ do


### PR DESCRIPTION
Nice to meet you!

Since I'm cross-compiling a Haskell project from Linux to Windows, QuasiQuotes is not available for me. So I intend to use `jvm` directly instead of `inline-java`.

It seems the example in jvm/README.md doesn't compile due to a change introduced in 2793b95f9efd2582f71ac393c55cadf33398c105.

I think I was able to update the example. Please let me know if there is any mistake.
