### PR TITLE
Allow to set the call to use to find classes.

### DIFF
--- a/jvm/src/Language/Java.hs
+++ b/jvm/src/Language/Java.hs
@@ -44,6 +44,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StaticPointers #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -58,6 +59,8 @@ module Language.Java
   , withJVM
   -- * JVM calls
   , classOf
+  , getClass
+  , setGetClassFunction
   , new
   , newArray
   , toArray
@@ -95,6 +98,7 @@ import qualified Data.Choice as Choice
 import qualified Data.Coerce as Coerce
 import Data.Constraint (Dict(..))
 import Data.Int
+import Data.IORef
 import Data.Proxy (Proxy(..))
 import Data.Typeable (Typeable, TypeRep, typeOf)
 import Data.Word
@@ -117,7 +121,7 @@ import Foreign.JNI hiding (throw)
 import Foreign.JNI.Types
 import qualified Foreign.JNI.String as JNI
 import GHC.TypeLits (KnownSymbol, symbolVal)
-import System.IO.Unsafe (unsafeDupablePerformIO)
+import System.IO.Unsafe (unsafeDupablePerformIO, unsafePerformIO)
 
 data Pop a where
   PopValue :: a -> Pop a
@@ -276,6 +280,30 @@ classOf
   -> JNI.String
 classOf x = JNI.fromChars (symbolVal (Proxy :: Proxy sym)) `const` coerce x
 
+-- | Sets the function to use for loading classes.
+--
+-- 'findClass' is used by default.
+--
+setGetClassFunction
+  :: (forall ty. IsReferenceType ty => Sing (ty :: JType) -> IO JClass)
+  -> IO ()
+setGetClassFunction f = writeIORef getClassFunctionRef $ GetClassFun f
+
+-- | Yields a class referece. It behaves as 'findClass' unless
+-- 'setGetClassFunction' is used.
+getClass :: IsReferenceType ty => Sing (ty :: JType) -> IO JClass
+getClass s = readIORef getClassFunctionRef >>= \(GetClassFun f) -> f s
+
+newtype GetClassFun =
+    GetClassFun (forall ty. IsReferenceType ty =>
+                   Sing (ty :: JType) -> IO JClass
+                )
+
+{-# NOINLINE getClassFunctionRef #-}
+getClassFunctionRef :: IORef GetClassFun
+getClassFunctionRef =
+    unsafePerformIO $ newIORef (GetClassFun (findClass . referenceTypeName))
+
 -- | Creates a new instance of the class whose name is resolved from the return
 -- type. For instance,
 --
@@ -296,7 +324,7 @@ new args = do
     let argsings = map jtypeOf args
         voidsing = sing :: Sing 'Void
         klass = unsafeDupablePerformIO $ do
-          lk <- findClass (referenceTypeName (sing :: Sing ('Class sym)))
+          lk <- getClass (sing :: Sing ('Class sym))
           gk <- newGlobalRef lk
           deleteLocalRef lk
           return gk
@@ -334,7 +362,7 @@ newArray sz = do
         Nothing -> fail $ "newArray of " ++ show tysing
         Just Dict -> do
           let klass = unsafeDupablePerformIO $ do
-                lk <- findClass (referenceTypeName tysing)
+                lk <- getClass tysing
                 gk <- newGlobalRef lk
                 deleteLocalRef lk
                 return gk
@@ -371,7 +399,7 @@ call obj mname args = do
     let argsings = map jtypeOf args
         retsing = sing :: Sing ty2
         klass = unsafeDupablePerformIO $ do
-                  lk <- findClass (referenceTypeName (sing :: Sing ty1))
+                  lk <- getClass (sing :: Sing ty1)
                   gk <- newGlobalRef lk
                   deleteLocalRef lk
                   return gk
@@ -403,8 +431,7 @@ callStatic cname mname args = do
     let argsings = map jtypeOf args
         retsing = sing :: Sing ty
         klass = unsafeDupablePerformIO $ do
-                  lk <- findClass
-                          (referenceTypeName (SClass (JNI.toChars cname)))
+                  lk <- getClass (SClass (JNI.toChars cname))
                   gk <- newGlobalRef lk
                   deleteLocalRef lk
                   return gk
@@ -434,7 +461,7 @@ getStaticField
 getStaticField cname fname = do
   let retsing = sing :: Sing ty
       klass = unsafeDupablePerformIO $ do
-                lk <- findClass (referenceTypeName (SClass (JNI.toChars cname)))
+                lk <- getClass (SClass (JNI.toChars cname))
                 gk <- newGlobalRef lk
                 deleteLocalRef lk
                 return gk
@@ -564,8 +591,7 @@ withStatic [d|
   instance Reify Bool where
     reify jobj = do
         let method = unsafeDupablePerformIO $ do
-              klass <- findClass
-                         (referenceTypeName (SClass "java.lang.Boolean"))
+              klass <- getClass (SClass "java.lang.Boolean")
               m <- getMethodID klass "booleanValue"
                      (methodSignature [] (SPrim "boolean"))
               deleteLocalRef klass
@@ -581,7 +607,7 @@ withStatic [d|
   instance Reify CChar where
     reify jobj = do
         let method = unsafeDupablePerformIO $ do
-              klass <- findClass (referenceTypeName (SClass "java.lang.Byte"))
+              klass <- getClass (SClass "java.lang.Byte")
               m <- getMethodID klass "byteValue"
                      (methodSignature [] (SPrim "byte"))
               deleteLocalRef klass
@@ -597,7 +623,7 @@ withStatic [d|
   instance Reify Int16 where
     reify jobj = do
         let method = unsafeDupablePerformIO $ do
-              klass <- findClass (referenceTypeName (SClass "java.lang.Short"))
+              klass <- getClass (SClass "java.lang.Short")
               m <- getMethodID klass "shortValue"
                      (methodSignature [] (SPrim "short"))
               deleteLocalRef klass
@@ -613,8 +639,7 @@ withStatic [d|
   instance Reify Int32 where
     reify jobj = do
         let method = unsafeDupablePerformIO $ do
-              klass <- findClass
-                         (referenceTypeName (SClass "java.lang.Integer"))
+              klass <- getClass (SClass "java.lang.Integer")
               m <- getMethodID klass "intValue"
                      (methodSignature [] (SPrim "int"))
               deleteLocalRef klass
@@ -630,7 +655,7 @@ withStatic [d|
   instance Reify Int64 where
     reify jobj = do
         let method = unsafeDupablePerformIO $ do
-              klass <- findClass (referenceTypeName (SClass "java.lang.Long"))
+              klass <- getClass (SClass "java.lang.Long")
               m <- getMethodID klass "longValue"
                      (methodSignature [] (SPrim "long"))
               deleteLocalRef klass
@@ -646,8 +671,7 @@ withStatic [d|
   instance Reify Word16 where
     reify jobj = do
         let method = unsafeDupablePerformIO $ do
-              klass <- findClass
-                         (referenceTypeName (SClass "java.lang.Character"))
+              klass <- getClass (SClass "java.lang.Character")
               m <- getMethodID klass "charValue"
                      (methodSignature [] (SPrim "char"))
               deleteLocalRef klass
@@ -663,7 +687,7 @@ withStatic [d|
   instance Reify Double where
     reify jobj = do
         let method = unsafeDupablePerformIO $ do
-              klass <- findClass (referenceTypeName (SClass "java.lang.Double"))
+              klass <- getClass (SClass "java.lang.Double")
               m <- getMethodID klass "doubleValue"
                      (methodSignature [] (SPrim "double"))
               deleteLocalRef klass
@@ -679,7 +703,7 @@ withStatic [d|
   instance Reify Float where
     reify jobj = do
         let method = unsafeDupablePerformIO $ do
-              klass <- findClass (referenceTypeName (SClass "java.lang.Float"))
+              klass <- getClass (SClass "java.lang.Float")
               m <- getMethodID klass "floatValue"
                      (methodSignature [] (SPrim "float"))
               deleteLocalRef klass


### PR DESCRIPTION
This is necessary in order to give a Haskell thread the ability to use class loaders that aren't available to JNI.findClass.

Related to https://github.com/tweag/sparkle/issues/72.