### PR TITLE
Avoid using showsSingPrec when building against singletons>=2.5

### DIFF
--- a/jni/src/Foreign/JNI/Types.hs
+++ b/jni/src/Foreign/JNI/Types.hs
@@ -172,7 +172,10 @@ data instance Sing (a :: JType) where
 realShowsPrec :: Show a => Int -> a -> ShowS
 realShowsPrec = showsPrec
 
-#if MIN_VERSION_singletons(2,4,0)
+#if MIN_VERSION_singletons(2,5,0)
+
+instance Show (Sing (a :: JType)) where
+#elif MIN_VERSION_singletons(2,4,0)
 
 instance Show (Sing (a :: JType)) where
   showsPrec = showsSingPrec


### PR DESCRIPTION
My environment is cabal-install-2.4.1.0, ghc-8.6.4, Arch Linux. (without stack)

The package singletons-2.5.*, which is the only available versions for base-4.12, doesn't define `showsSingPrec`.

A new `#if` branch is added to avoid using `showsSingPrec` to prevent compilation failure.

In addition, the

    instance Show (Sing (a :: [JType]))

is excluded as well because `Data.Singletons.ShowSing` now defines the

    instance (ShowSing a, ShowSing [a]) => Show (Sing z),

which leads to an ambiguous instance error.

I didn't added an entry to `CHANGELOG.md` because I couldn't figure out where to put a `jni`-specific one.