### PR TITLE
Upgrade to latest rules_haskell

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,2 @@
+common --host_javabase=@local_jdk//:jdk
+try-import .bazelrc.local

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - image: nixos/nix
     working_directory: ~/sparkle
     environment:
-      - NIXRUN: nix-shell -I nixpkgs=./nixpkgs.nix -p gcc bazel --run
+      - NIXRUN: nix-shell -I nixpkgs=./nixpkgs.nix --pure -p gcc bazel stack nix openjdk11 ghc python3 --run
     steps:
       - checkout
       - run:
@@ -48,7 +48,9 @@ jobs:
             $NIXRUN "echo nix dependencies installed"
       - run:
           name: Build project
-          command: $NIXRUN "bazel build --jobs 2 //..."
+          command: |
+            echo "common --host_platform=@io_tweag_rules_haskell//haskell/platforms:linux_x86_64_nixpkgs" > .bazelrc.local
+            $NIXRUN "bazel build --jobs 2 //..."
 
   build-darwin-brew:
     macos:

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,68 +1,50 @@
-package(default_visibility = ["//visibility:public"])
+exports_files(["nixpkgs.nix"])
 
 load(
-  "@io_tweag_rules_haskell//haskell:haskell.bzl",
-  "haskell_test",
-  "haskell_library",
-  "haskell_toolchain",
+    "@io_tweag_rules_haskell//haskell:haskell.bzl",
+    "ghc_plugin",
+    "haskell_library",
 )
 
 cc_library(
-  name = "bctable",
-  srcs = ["cbits/bctable.c"],
-  hdrs = ["cbits/bctable.h"],
-  strip_include_prefix = "cbits",
-)
-
-haskell_toolchain(
-  name = "inline-java-toolchain",
-  version = "8.2.2",
-  tools = "@inline-java-toolchain//:bin",
-  extra_binaries = ["@openjdk//:bin"],
+    name = "bctable",
+    hdrs = ["cbits/bctable.h"],
+    srcs = ["cbits/bctable.c"],
+    strip_include_prefix = "cbits",
 )
 
 haskell_library(
-  name = "inline-java",
-  src_strip_prefix = "src",
-  # cbits/bctable.h is included here so it can be found by Plugin.hs
-  # at the same location when building with bazel as with stack.
-  srcs = glob(['src/**/*.hs', 'src/**/*.hsc', 'cbits/bctable.h']),
-  deps = [
-    "//jni",
-    "//jvm",
-    ":bctable",
-  ],
-  prebuilt_dependencies = [
-    "base",
-    "bytestring",
-    "Cabal",
-    "directory",
-    "filepath",
-    "filemanip",
-    "ghc",
-    "language-java",
-    "mtl",
-    "process",
-    "text",
-    "template-haskell",
-    "temporary"
-  ],
+    name = "inline-java",
+    # cbits/bctable.h is included here so it can be found by Plugin.hs
+    # at the same location when building with bazel as with stack.
+    srcs = glob(['src/**/*.hs', 'src/**/*.hsc', 'cbits/bctable.h']),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//jni",
+        "//jvm",
+        ":bctable",
+        "@stackage//:Cabal",
+        "@stackage//:base",
+        "@stackage//:bytestring",
+        "@stackage//:directory",
+        "@stackage//:filemanip",
+        "@stackage//:filepath",
+        "@stackage//:ghc",
+        "@stackage//:language-java",
+        "@stackage//:mtl",
+        "@stackage//:process",
+        "@stackage//:template-haskell",
+        "@stackage//:temporary",
+        "@stackage//:text",
+    ],
 )
 
-# Can't find hspec-discover
-#haskell_test(
-#  name = "spec",
-#  src_strip_prefix = "tests",
-#  srcs = glob(["tests/**/*.hs"]),
-#  deps = [
-#    "//jni",
-#    "//jvm",
-#    ":inline-java"
-#  ],
-#  prebuilt_dependencies = [
-#    "base",
-#    "hspec",
-#    "text",
-#  ],
-#  size = "small",
-#)
+ghc_plugin(
+    name = "inline-java-plugin",
+    args = ["$(JAVABASE)/bin/javac"],
+    module = "Language.Java.Inline.Plugin",
+    toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
+    tools = ["@bazel_tools//tools/jdk:javac"],
+    visibility = ["//visibility:public"],
+    deps = [":inline-java"],
+)

--- a/inline-java.cabal
+++ b/inline-java.cabal
@@ -41,7 +41,7 @@ library
     Cabal >=1.24.2,
     directory >=1.2,
     filepath >=1,
-    ghc >=8.0.2 && <8.5,
+    ghc >=8.4 && <8.5,
     jni >=0.4 && <0.7,
     jvm >=0.4 && <0.5,
     language-java >=0.2,

--- a/inline-java.cabal
+++ b/inline-java.cabal
@@ -68,3 +68,4 @@ test-suite spec
     inline-java,
     text
   default-language: Haskell2010
+  ghc-options: -fplugin=Language.Java.Inline.Plugin -DHSPEC_DISCOVER=hspec-discover

--- a/inline-java.cabal
+++ b/inline-java.cabal
@@ -41,7 +41,7 @@ library
     Cabal >=1.24.2,
     directory >=1.2,
     filepath >=1,
-    ghc >=8.4 && <8.5,
+    ghc >=8.4 && <8.7,
     jni >=0.4 && <0.7,
     jvm >=0.4 && <0.5,
     language-java >=0.2,

--- a/jni/BUILD.bazel
+++ b/jni/BUILD.bazel
@@ -1,31 +1,21 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
-  "@io_tweag_rules_haskell//haskell:haskell.bzl",
-  "haskell_cc_import",
-  "haskell_library",
-)
-
-haskell_cc_import(
-  name = "openjdk",
-  shared_library = "@openjdk//:lib",
-  hdrs = ["@openjdk//:jni_header", "@openjdk//:jni_md_header"],
-  strip_include_prefix = "/external/openjdk/include",
+    "@io_tweag_rules_haskell//haskell:haskell.bzl",
+    "haskell_library",
 )
 
 haskell_library(
-  name = "jni",
-  src_strip_prefix = "src",
-  srcs = glob(['src/**/*.hs', 'src/**/*.hsc']),
-  deps = [":openjdk"],
-  prebuilt_dependencies = [
-    "base",
-    "bytestring",
-    "choice",
-    "containers",
-    "constraints",
-    "deepseq",
-    "inline-c",
-    "singletons",
-  ],
+    name = "jni",
+    srcs = glob(['src/**/*.hs', 'src/**/*.hsc']),
+    deps = [
+        "@openjdk//:lib",
+        "@stackage//:base",
+        "@stackage//:bytestring",
+        "@stackage//:choice",
+        "@stackage//:containers",
+        "@stackage//:constraints",
+        "@stackage//:deepseq",
+        "@stackage//:inline-c",
+        "@stackage//:singletons",
+    ],
+    visibility = ["//visibility:public"],
 )

--- a/jni/jni.cabal
+++ b/jni/jni.cabal
@@ -42,7 +42,7 @@ library
     containers >=0.5,
     constraints >=0.8,
     deepseq >=1.4.2,
-    singletons >=2.0
+    singletons >=2.5
   if impl(ghc < 8.2.1)
     build-depends:
       inline-c >=0.5.6.1 && <0.6

--- a/jni/src/Foreign/JNI/Types.hs
+++ b/jni/src/Foreign/JNI/Types.hs
@@ -81,7 +81,6 @@ import Data.Singletons
   , SomeSing(..)
   )
 import Data.Singletons.Prelude (Sing(..))
-import Data.Singletons.ShowSing (ShowSing(..))
 import Data.Singletons.TypeLits (KnownSymbol, symbolVal)
 import Data.Word
 import Foreign.C (CChar)

--- a/jvm-batching/BUILD.bazel
+++ b/jvm-batching/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
   "@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_library",
@@ -7,48 +5,27 @@ load(
 )
 
 java_library(
-  name = "jar",
-  srcs = glob(["src/main/java/**/*.java"]),
+    name = "jar",
+    srcs = glob(["src/main/java/**/*.java"]),
+    visibility = ["//visibility:public"],
 )
 
 haskell_library(
-  name = "jvm-batching",
-  src_strip_prefix = "src/main/haskell",
-  srcs = glob(['src/main/haskell/**/*.hs']),
-  deps = [
-    ":jar",
-    "//jni",
-    "//jvm",
-    "//:inline-java",
-  ],
-  prebuilt_dependencies = [
-    "base",
-    "bytestring",
-    "distributed-closure",
-    "exceptions",
-    "singletons",
-    "text",
-    "vector",
-  ],
+    name = "jvm-batching",
+    srcs = glob(['src/main/haskell/**/*.hs']),
+    visibility = ["//visibility:public"],
+    plugins = ["//:inline-java-plugin"],
+    deps = [
+        ":jar",
+        "//jni",
+        "//jvm",
+        "//:inline-java",
+        "@stackage//:base",
+        "@stackage//:bytestring",
+        "@stackage//:distributed-closure",
+        "@stackage//:exceptions",
+        "@stackage//:singletons",
+        "@stackage//:text",
+        "@stackage//:vector",
+    ],
 )
-
-# Can't find hspec-discover
-#haskell_test(
-#  name = "spec",
-#  src_strip_prefix = "src/test/haskell",
-#  srcs = glob(["src/test/haskell/**/*.hs"]),
-#  deps = [
-#    "//:inline-java",
-#    "//jvm",
-#    "//jvm-batching",
-#  ],
-#  prebuilt_dependencies = [
-#    "base",
-#    "bytestring",
-#    "hspec",
-#    "streaming",
-#    "text",
-#    "vector",
-#  ],
-#  size = "small",
-#)

--- a/jvm-batching/jvm-batching.cabal
+++ b/jvm-batching/jvm-batching.cabal
@@ -49,6 +49,7 @@ library
     singletons >= 2.2,
     text,
     vector
+  ghc-options: -fplugin=Language.Java.Inline.Plugin
 
 test-suite spec
   type:
@@ -68,6 +69,7 @@ test-suite spec
     text,
     vector
   default-language: Haskell2010
+  ghc-options: -DHSPEC_DISCOVER=hspec-discover
 
 benchmark micro-benchmarks
   type: exitcode-stdio-1.0

--- a/jvm-batching/src/main/haskell/Language/Java/Batching.hs
+++ b/jvm-batching/src/main/haskell/Language/Java/Batching.hs
@@ -18,7 +18,6 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# OPTIONS_GHC -fplugin=Language.Java.Inline.Plugin #-}
 
 -- | This module provides composable batched marshalling.
 --

--- a/jvm-batching/src/test/haskell/BUILD.bazel
+++ b/jvm-batching/src/test/haskell/BUILD.bazel
@@ -1,0 +1,32 @@
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_test",
+)
+
+haskell_test(
+    name = "spec",
+    srcs = glob(["**/*.hs"]),
+    extra_srcs = ["@openjdk//:rpath"],
+    compiler_flags = [
+        "-optl-Wl,@$(location @openjdk//:rpath)",
+        "-DHSPEC_DISCOVER=$(location @hspec-discover//:bin)",
+    ],
+    size = "small",
+    plugins = ["//:inline-java-plugin"],
+    tools = ["@hspec-discover//:bin"],
+    deps = [
+        "//:inline-java",
+        "//jvm",
+        "//jvm-batching",
+        "//jvm-batching:jar",
+        "//jvm-streaming",
+        "@stackage//:base",
+        "@stackage//:bytestring",
+        "@stackage//:hspec",
+        "@stackage//:streaming",
+        "@stackage//:text",
+        "@stackage//:vector",
+    ],
+    # Failing test. TODO Reenable.
+    tags = ["manual"],
+)

--- a/jvm-batching/src/test/haskell/Language/Java/BatchingSpec.hs
+++ b/jvm-batching/src/test/haskell/Language/Java/BatchingSpec.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
-{-# OPTIONS_GHC -fplugin=Language.Java.Inline.Plugin #-}
 
 module Language.Java.BatchingSpec where
 

--- a/jvm-batching/src/test/haskell/Spec.hs
+++ b/jvm-batching/src/test/haskell/Spec.hs
@@ -1,1 +1,2 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}
+{-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -F -pgmF HSPEC_DISCOVER -optF --module-name=Spec #-}

--- a/jvm-streaming/BUILD.bazel
+++ b/jvm-streaming/BUILD.bazel
@@ -1,45 +1,23 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
   "@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_library",
-  "haskell_test",
 )
 
 haskell_library(
-  name = "jvm-streaming",
-  src_strip_prefix = "src/main/haskell",
-  srcs = glob(['src/main/haskell/**/*.hs']),
-  deps = [
-    "//jvm-batching:jar",
-    "//jni",
-    "//jvm",
-    "//jvm-batching",
-    "//:inline-java",
-  ],
-  prebuilt_dependencies = [
-    "base",
-    "distributed-closure",
-    "singletons",
-    "streaming",
-    "vector",
-  ],
+    name = "jvm-streaming",
+    srcs = glob(['src/main/haskell/**/*.hs']),
+    visibility = ["//visibility:public"],
+    plugins = ["//:inline-java-plugin"],
+    deps = [
+        "//jvm-batching:jar",
+        "//jni",
+        "//jvm",
+        "//jvm-batching",
+        "//:inline-java",
+        "@stackage//:base",
+        "@stackage//:distributed-closure",
+        "@stackage//:singletons",
+        "@stackage//:streaming",
+        "@stackage//:vector",
+    ],
 )
-
-# Can't find hspec-discover
-#haskell_test(
-#  name = "spec",
-#  src_strip_prefix = "src/test/haskell",
-#  srcs = glob(["src/test/haskell/**/*.hs"]),
-#  deps = [
-#    "//:inline-java",
-#    "//jvm",
-#    "//jvm-streaming",
-#  ],
-#  prebuilt_dependencies = [
-#    "base",
-#    "hspec",
-#    "streaming",
-#  ],
-#  size = "small",
-#)

--- a/jvm-streaming/jvm-streaming.cabal
+++ b/jvm-streaming/jvm-streaming.cabal
@@ -41,6 +41,7 @@ library
     singletons >= 2.2,
     streaming >= 0.1.4,
     vector
+  ghc-options: -fplugin=Language.Java.Inline.Plugin
 
 test-suite spec
   type:
@@ -59,6 +60,8 @@ test-suite spec
     streaming,
     text
   default-language: Haskell2010
+  ghc-options: -fplugin=Language.Java.Inline.Plugin -DHSPEC_DISCOVER=hspec-discover
+
 
 benchmark micro-benchmarks
   type: exitcode-stdio-1.0

--- a/jvm-streaming/src/main/haskell/Language/Java/Streaming.hs
+++ b/jvm-streaming/src/main/haskell/Language/Java/Streaming.hs
@@ -19,7 +19,6 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
-{-# OPTIONS_GHC -fplugin=Language.Java.Inline.Plugin #-}
 
 module Language.Java.Streaming
   ( reifyStreamWithBatching

--- a/jvm-streaming/src/test/haskell/BUILD.bazel
+++ b/jvm-streaming/src/test/haskell/BUILD.bazel
@@ -1,0 +1,29 @@
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_test",
+)
+
+haskell_test(
+    name = "spec",
+    srcs = glob(["**/*.hs"], exclude = ["Main.hs"]),
+    extra_srcs = ["@openjdk//:rpath"],
+    compiler_flags = [
+        "-optl-Wl,@$(location @openjdk//:rpath)",
+        "-DHSPEC_DISCOVER=$(location @hspec-discover//:bin)",
+    ],
+    size = "small",
+    plugins = ["//:inline-java-plugin"],
+    tools = ["@hspec-discover//:bin"],
+    deps = [
+        "//:inline-java",
+        "//jvm",
+        "//jvm-batching:jar",
+        "//jvm-streaming",
+        "@stackage//:base",
+        "@stackage//:hspec",
+        "@stackage//:streaming",
+        "@stackage//:text",
+    ],
+    # Failing test. TODO Reenable.
+    tags = ["manual"],
+)

--- a/jvm-streaming/src/test/haskell/Language/Java/StreamingSpec.hs
+++ b/jvm-streaming/src/test/haskell/Language/Java/StreamingSpec.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# OPTIONS_GHC -fplugin=Language.Java.Inline.Plugin #-}
 
 module Language.Java.StreamingSpec where
 

--- a/jvm-streaming/src/test/haskell/Language/Java/StreamingSpec.hs
+++ b/jvm-streaming/src/test/haskell/Language/Java/StreamingSpec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fplugin=Language.Java.Inline.Plugin #-}
 
 module Language.Java.StreamingSpec where
@@ -19,26 +20,26 @@ spec = do
       it "succeeds on empty lists" $ do
         vals <- reflect [1..0 :: Int32]
         iterator <- [java| java.util.Arrays.asList($vals).iterator() |]
-        stream <- reify iterator
+        stream :: Stream (Of Int32) IO () <- reify iterator
         Streaming.toList_ stream `shouldReturn` [1..0 :: Int32]
       it "succeeds on singleton lists" $ do
         vals <- reflect [1 :: Int32]
         iterator <- [java| java.util.Arrays.asList($vals).iterator() |]
-        stream <- reify iterator
+        stream :: Stream (Of Int32) IO () <- reify iterator
         Streaming.toList_ stream `shouldReturn` [1 :: Int32]
       it "succeeds on non-trivial lists" $ do
         vals <- reflect [1..10000 :: Int32]
         iterator <- [java| java.util.Arrays.asList($vals).iterator() |]
-        stream <- reify iterator
+        stream :: Stream (Of Int32) IO () <- reify iterator
         Streaming.toList_ stream `shouldReturn` [1..10000 :: Int32]
     describe "streams" $ do
       it "have the property that reify . reflect == id" $ do
         iterator <- reflect (Streaming.each [1..10000] :: Stream (Of Int32) IO ())
-        stream <- reify iterator
+        stream :: Stream (Of Int32) IO () <- reify iterator
         Streaming.toList_ stream `shouldReturn` [1..10000 :: Int32]
       it "don't redo effects" $ do
         ref <- newIORef (1 :: Int32)
         iterator <- reflect $
           Streaming.replicateM 10 $ atomicModifyIORef ref (\i -> (i + 1, i))
-        stream <- reify iterator
+        stream :: Stream (Of Int32) IO () <- reify iterator
         Streaming.toList_ stream `shouldReturn` [1..10 :: Int32]

--- a/jvm-streaming/src/test/haskell/MainBazel.hs
+++ b/jvm-streaming/src/test/haskell/MainBazel.hs
@@ -1,0 +1,8 @@
+module Main where
+
+import Language.Java (withJVM)
+import qualified Spec
+import Test.Hspec
+
+main :: IO ()
+main = withJVM [] $ hspec Spec.spec

--- a/jvm-streaming/src/test/haskell/Spec.hs
+++ b/jvm-streaming/src/test/haskell/Spec.hs
@@ -1,1 +1,2 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}
+{-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -F -pgmF HSPEC_DISCOVER -optF --module-name=Spec #-}

--- a/jvm/BUILD.bazel
+++ b/jvm/BUILD.bazel
@@ -1,26 +1,22 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
   "@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_library",
 )
 
 haskell_library(
-  name = "jvm",
-  src_strip_prefix = "src",
-  srcs = glob(['src/**/*.hs']),
-  deps = [
-    "//jni",
-  ],
-  prebuilt_dependencies = [
-    "base",
-    "bytestring",
-    "constraints",
-    "choice",
-    "distributed-closure",
-    "exceptions",
-    "singletons",
-    "text",
-    "vector",
-  ],
+    name = "jvm",
+    srcs = glob(['src/**/*.hs']),
+    deps = [
+        "//jni",
+        "@stackage//:base",
+        "@stackage//:bytestring",
+        "@stackage//:constraints",
+        "@stackage//:choice",
+        "@stackage//:distributed-closure",
+        "@stackage//:exceptions",
+        "@stackage//:singletons",
+        "@stackage//:text",
+        "@stackage//:vector",
+    ],
+    visibility = ["//visibility:public"],
 )

--- a/jvm/jvm.cabal
+++ b/jvm/jvm.cabal
@@ -52,6 +52,7 @@ test-suite spec
     text
   default-language: Haskell2010
   extra-libraries: pthread
+  ghc-options: -DHSPEC_DISCOVER=hspec-discover
 
 benchmark micro-benchmarks
   type: exitcode-stdio-1.0

--- a/jvm/tests/BUILD.bazel
+++ b/jvm/tests/BUILD.bazel
@@ -1,0 +1,24 @@
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_test",
+)
+
+haskell_test(
+    name = "spec",
+    srcs = glob(['**/*.hs']),
+    extra_srcs = ["@openjdk//:rpath"],
+    compiler_flags = [
+        "-optl-Wl,@$(location @openjdk//:rpath)",
+        "-DHSPEC_DISCOVER=$(location @hspec-discover//:bin)",
+    ],
+    timeout = "short",
+    tools = ["@hspec-discover//:bin"],
+    deps = [
+        "//jvm",
+        "//jni",
+        "@stackage//:base",
+        "@stackage//:bytestring",
+        "@stackage//:hspec",
+        "@stackage//:text",
+    ],
+)

--- a/jvm/tests/Spec.hs
+++ b/jvm/tests/Spec.hs
@@ -1,1 +1,2 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}
+{-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -F -pgmF HSPEC_DISCOVER -optF --module-name=Spec #-}

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,1 +1,1 @@
-import (fetchTarball "https://github.com/nixos/nixpkgs/archive/1fa2503f9dba814eb23726a25642d2180ce791c3.tar.gz")
+import (fetchTarball "https://github.com/nixos/nixpkgs/archive/6d3b7390bc683eea884f9e1d5846632e4fe10428.tar.gz")

--- a/src/Language/Java/Inline/Cabal.hs
+++ b/src/Language/Java/Inline/Cabal.hs
@@ -17,7 +17,6 @@ module Language.Java.Inline.Cabal
 
 import Control.Exception (evaluate)
 import Control.Monad (when)
-import Data.Monoid
 import Data.List (intersperse, isPrefixOf)
 import Distribution.Simple
 import Distribution.Simple.Setup (BuildFlags)

--- a/src/Language/Java/Inline/Plugin.hs
+++ b/src/Language/Java/Inline/Plugin.hs
@@ -30,12 +30,7 @@ import IfaceEnv (lookupOrigNameCache)
 import qualified Language.Haskell.TH as TH
 import qualified Language.Haskell.TH.Syntax as TH
 import Language.Java.Inline.Magic
-#if MIN_VERSION_ghc(8, 2, 1)
 import NameCache (nsNames)
-#endif
-#if MIN_VERSION_ghc(8, 4, 0)
-import Prelude hiding ((<>))
-#endif
 import TyCoRep
 import TysWiredIn (nilDataConName, consDataConName)
 import System.Directory (listDirectory)
@@ -43,6 +38,7 @@ import System.FilePath ((</>), (<.>), takeDirectory)
 import System.IO (withFile, IOMode(WriteMode), hPutStrLn, stderr)
 import System.IO.Temp (withSystemTempDirectory)
 import System.Process (callProcess)
+import Prelude hiding ((<>))
 
 -- The 'java' quasiquoter produces annotations of type 'JavaImport', and it also
 -- inserts calls in the code to the function 'qqMarker'.
@@ -65,9 +61,6 @@ plugin = defaultPlugin
   where
     install :: [CommandLineOption] -> [CoreToDo] -> CoreM [CoreToDo]
     install args todo = do
-#if !MIN_VERSION_ghc(8,2,1)
-      reinitializeGlobals
-#endif
       return (CoreDoPluginPass "inline-java" (qqPass args) : todo)
 
     qqPass :: [CommandLineOption] -> ModGuts -> CoreM ModGuts

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 require-stack-version: ">= 1.6"
 
-resolver: lts-10.1
+resolver: lts-13.20
 
 packages:
 - .
@@ -9,9 +9,6 @@ packages:
 - jvm-batching
 - jvm-streaming
 - examples/classpath
-
-extra-deps:
-- distributed-closure-0.3.5
 
 nix:
   shell-file: shell.nix

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,0 +1,26 @@
+load(
+    "@io_tweag_rules_haskell//haskell:haskell.bzl",
+    "haskell_test",
+)
+
+haskell_test(
+    name = "spec",
+    srcs = glob(["**/*.hs"]),
+    extra_srcs = ["@openjdk//:rpath"],
+    compiler_flags = [
+        "-optl-Wl,@$(location @openjdk//:rpath)",
+        "-DHSPEC_DISCOVER=$(location @hspec-discover//:bin)",
+    ],
+    deps = [
+        "//jni",
+        "//jvm",
+        "//:inline-java",
+        "@stackage//:base",
+        "@stackage//:hspec",
+        "@stackage//:text",
+        "@stackage//:unix",
+    ],
+    size = "small",
+    plugins = ["//:inline-java-plugin"],
+    tools = ["@hspec-discover//:bin"],
+)

--- a/tests/Language/Java/InlineSpec.hs
+++ b/tests/Language/Java/InlineSpec.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeOperators #-}
-{-# OPTIONS_GHC -fplugin=Language.Java.Inline.Plugin #-}
 -- Test that inline-java produces code without warnings or errors.
 {-# OPTIONS_GHC -dcore-lint -Wall -Werror #-}
 

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1,1 +1,2 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}
+{-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -F -pgmF HSPEC_DISCOVER -optF --module-name=Spec #-}


### PR DESCRIPTION
This includes bazelification that goes further than previously
accomplished: we can now run inline-java's test suite. But we still
can't run binaries that need a custom `CLASSPATH`. Those are probably
better off as a `java_binary` rather than native binary.