### PR TITLE
Use an abstract monad in the linear interfaces

### DIFF
--- a/jni/src/linear-types/Control/Monad/Lift/Linear.hs
+++ b/jni/src/linear-types/Control/Monad/Lift/Linear.hs
@@ -1,0 +1,30 @@
+-- | A class to lift non-linear monads into linear monads.
+--
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+module Control.Monad.Lift.Linear where
+
+import qualified Control.Monad as NonLinear
+import qualified Control.Monad.Linear as Linear
+import Prelude.Linear
+
+-- | Lift a non-linear monad into a linear monad.
+--
+-- Laws:
+--
+-- > lift . return = return
+--
+-- > liftU . return = return . Unrestricted
+--
+-- > lift (m >>= f) = liftU m >>= \(Unrestricted a) -> lift (f a)
+--
+-- > liftU (m >>= f) = liftU m >>= \(Unrestricted a) -> liftU (f a)
+--
+class (Linear.Monad m, NonLinear.Monad (LiftedM m)) => MonadLift m where
+  type LiftedM m :: * -> *
+  lift :: LiftedM m a -> m a
+  liftU :: LiftedM m a -> m (Unrestricted a)

--- a/jni/src/linear-types/System/IO/Linear/Extras.hs
+++ b/jni/src/linear-types/System/IO/Linear/Extras.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module System.IO.Linear.Extras where
+
+import qualified Control.Monad.IO.Class as NonLinear
+import Control.Monad.Lift.Linear
+import Prelude.Linear
+import qualified System.IO.Linear as Linear
+
+instance MonadLift Linear.IO where
+  type LiftedM Linear.IO = IO
+  lift io = Linear.fromSystemIO io
+  liftU = Linear.fromSystemIOU
+
+type MonadIO m = (MonadLift m, NonLinear.MonadIO (LiftedM m))
+
+liftIO :: MonadIO m => IO a -> m a
+liftIO io = lift (NonLinear.liftIO io)
+
+liftIOU :: MonadIO m => IO a -> m (Unrestricted a)
+liftIOU io = liftU (NonLinear.liftIO io)

--- a/jvm/src/linear-types/Language/Java/Safe.hs
+++ b/jvm/src/linear-types/Language/Java/Safe.hs
@@ -84,6 +84,7 @@ module Language.Java.Safe
   ) where
 
 import Control.Exception (evaluate)
+import Control.Monad.IO.Class.Linear (MonadIO, liftIO, liftIOU)
 import Control.Monad.Linear hiding ((<$>))
 import Data.ByteString (ByteString)
 import qualified Data.Choice as Choice
@@ -105,7 +106,6 @@ import GHC.TypeLits (KnownSymbol, symbolVal)
 
 import qualified Language.Java as Java
 import qualified Language.Java.Internal as Java
-import qualified System.IO.Linear as Linear
 import Prelude ((.))
 import qualified Prelude
 import Prelude.Linear hiding ((.))
@@ -223,12 +223,12 @@ classOf = Unsafe.toLinear $ \x -> (,) x $
 --    return x
 -- @
 new
-  :: forall a sym.
-     (Ty a ~ 'Class sym, Coercible a)
+  :: forall a sym m.
+     (Ty a ~ 'Class sym, Coercible a, MonadIO m)
   => [JValue]
-  ->. Linear.IO a
+  ->. m a
 {-# INLINE new #-}
-new = Unsafe.toLinear $ \args -> fmap unsafeUncoerce $ Linear.fromSystemIO $
+new = Unsafe.toLinear $ \args -> fmap unsafeUncoerce $ liftIO Prelude.$
     JObject . J <$> Java.newJ @sym (toJNIJValues args)
       Prelude.<* deleteLinearJObjects args
 
@@ -242,17 +242,17 @@ new = Unsafe.toLinear $ \args -> fmap unsafeUncoerce $ Linear.fromSystemIO $
 -- do arr :: 'J' (''Array' (''Prim' "boolean")) <- 'newArray' 50
 --    return arr
 -- @
-newArray :: forall ty. SingI ty => Int32 -> Linear.IO (J ('Array ty))
+newArray :: (MonadIO m, SingI ty) => Int32 -> m (J ('Array ty))
 {-# INLINE newArray #-}
-newArray sz = Linear.fromSystemIO $ J <$> Java.newArray sz
+newArray sz = liftIO (J <$> Java.newArray sz)
 
 -- | Creates an array from a list of references.
 toArray
-  :: forall ty. (SingI ty, IsReferenceType ty)
+  :: (SingI ty, IsReferenceType ty, MonadIO m)
   => [J ty]
-  ->. Linear.IO ([J ty], J ('Array ty))
+  ->. m ([J ty], J ('Array ty))
 toArray = Unsafe.toLinear $ \xs ->
-  Linear.fromSystemIO $ (,) xs . J <$> Java.toArray (Coerce.coerce xs)
+  liftIO ((,) xs . J <$> Java.toArray (Coerce.coerce xs))
 
 -- | The Swiss Army knife for calling Java methods. Give it an object or
 -- any data type coercible to one, the name of a method, and a list of
@@ -264,21 +264,22 @@ toArray = Unsafe.toLinear $ \xs ->
 -- appropriately on the class instance and/or on the arguments to invoke the
 -- right method.
 call
-  :: forall a b ty1 ty2.
+  :: forall a b ty1 ty2 m.
      ( ty1 ~ Ty a
      , ty2 ~ Ty b
      , IsReferenceType ty1
      , Coercible a
      , Coercible b
      , Coerce.Coercible a (J ty1)
+     , MonadIO m
      )
   => a -- ^ Any object or value 'Coercible' to one
   ->. JNI.String -- ^ Method name
   -> [JValue] -- ^ Arguments
-  ->. Linear.IO b
+  ->. m b
 {-# INLINE call #-}
 call = Unsafe.toLinear $ \obj mname -> Unsafe.toLinear $ \args ->
-    Linear.fromSystemIO $ strictUnsafeUncoerce Prelude.$ do
+    liftIO Prelude.$ strictUnsafeUncoerce Prelude.$ do
       fromJNIJValue <$>
         Java.callToJValue @ty1
           (sing :: Sing ty1) (Coerce.coerce obj) mname (toJNIJValues args)
@@ -294,26 +295,26 @@ fromJNIJValue = \case
 
 -- | Same as 'call', but for static methods.
 callStatic
-  :: forall a ty. (ty ~ Ty a, Coercible a)
+  :: forall a ty m. (ty ~ Ty a, Coercible a, MonadIO m)
   => JNI.String -- ^ Class name
   -> JNI.String -- ^ Method name
   -> [JValue] -- ^ Arguments
-  ->. Linear.IO a
+  ->. m a
 {-# INLINE callStatic #-}
 callStatic cname mname = Unsafe.toLinear $ \args ->
-    Linear.fromSystemIO $ strictUnsafeUncoerce Prelude.$
+    liftIO Prelude.$ strictUnsafeUncoerce Prelude.$
       fromJNIJValue <$>
       Java.callStaticToJValue (sing :: Sing ty) cname mname (toJNIJValues args)
         Prelude.<* deleteLinearJObjects args
 
 -- | Get a static field.
 getStaticField
-  :: forall a ty. (ty ~ Ty a, Coercible a)
+  :: forall a ty m. (ty ~ Ty a, Coercible a, MonadIO m)
   => JNI.String -- ^ Class name
   -> JNI.String -- ^ Static field name
-  -> Linear.IO a
+  -> m a
 getStaticField cname fname =
-    Linear.fromSystemIO $ strictUnsafeUncoerce Prelude.$
+    liftIO Prelude.$ strictUnsafeUncoerce Prelude.$
       fromJNIJValue <$>
         Java.getStaticFieldAsJValue (sing :: Sing ty) cname fname
 
@@ -344,18 +345,17 @@ class (SingI (Interp a), IsReferenceType (Interp a)) => Interpretation (a :: k) 
 class Interpretation a => Reify a where
   -- | Invariant: The result and the argument share no direct JVM object
   -- references.
-  reify :: J (Interp a) ->. Linear.IO (J (Interp a), Unrestricted a)
+  reify :: MonadIO m => J (Interp a) ->. m (J (Interp a), Unrestricted a)
 
   default reify
-    :: (Java.Coercible a, Interp a ~ Java.Ty a)
+    :: (Java.Coercible a, Interp a ~ Java.Ty a, MonadIO m)
     => J (Interp a)
-    ->. Linear.IO (J (Interp a), Unrestricted a)
-  reify = Unsafe.toLinear $ \x -> fmap ((,) x)
-      (Linear.fromSystemIOU
-        (Java.unsafeUncoerce . Java.JObject <$> JNI.newLocalRef (unJ x))
-      )
+    ->. m (J (Interp a), Unrestricted a)
+  reify = Unsafe.toLinear $ \x -> fmap ((,) x) $
+      liftIOU Prelude.$
+        Java.unsafeUncoerce . Java.JObject <$> JNI.newLocalRef (unJ x)
 
-reify_ :: Reify a => J (Interp a) ->. Linear.IO (Unrestricted a)
+reify_ :: (Reify a, MonadIO m) => J (Interp a) ->. m (Unrestricted a)
 reify_ _j = reify _j >>= \(_j, a) -> a <$ deleteLocalRef _j
 
 -- | Inject a concrete Haskell value into the space of Java objects. That is to
@@ -364,30 +364,30 @@ reify_ _j = reify _j >>= \(_j, a) -> a <$ deleteLocalRef _j
 class Interpretation a => Reflect a where
   -- | Invariant: The result and the argument share no direct JVM object
   -- references.
-  reflect :: a -> Linear.IO (J (Interp a))
+  reflect :: MonadIO m => a -> m (J (Interp a))
 
   default reflect
-    :: (Java.Coercible a, Interp a ~ Java.Ty a)
+    :: (Java.Coercible a, Interp a ~ Java.Ty a, MonadIO m)
     => a
-    -> Linear.IO (J (Interp a))
-  reflect x = Linear.fromSystemIO (J <$> JNI.newLocalRef (Java.jobject x))
+    -> m (J (Interp a))
+  reflect x = liftIO (J <$> JNI.newLocalRef (Java.jobject x))
 
 instance (SingI ty, IsReferenceType ty) => Interpretation (Java.J ty) where type Interp (Java.J ty) = ty
 instance Interpretation (Java.J ty) => Reify (Java.J ty)
 instance Interpretation (Java.J ty) => Reflect (Java.J ty)
 
 javaReify
-  :: (Java.Interp a ~ Interp a, Java.Reify a)
+  :: (Java.Interp a ~ Interp a, Java.Reify a, MonadIO m)
   => J (Interp a)
-  ->. Linear.IO (J (Interp a), Unrestricted a)
+  ->. m (J (Interp a), Unrestricted a)
 javaReify = Unsafe.toLinear $ \j ->
-    Linear.fromSystemIO ((,) j . Unrestricted <$> Java.reify (unJ j))
+    liftIO ((,) j . Unrestricted <$> Java.reify (unJ j))
 
 javaReflect
-  :: (Java.Interp a ~ Interp a, Java.Reflect a)
+  :: (Java.Interp a ~ Interp a, Java.Reflect a, MonadIO m)
   => a
-  -> Linear.IO (J (Interp a))
-javaReflect a = fmap J $ Linear.fromSystemIO (Java.reflect a)
+  -> m (J (Interp a))
+javaReflect a = fmap J $ liftIO (Java.reflect a)
 
 instance Interpretation () where type Interp () = Java.Interp ()
 instance Reify () where reify = javaReify

--- a/src/common/Language/Java/Inline/Internal/QQMarker.hs
+++ b/src/common/Language/Java/Inline/Internal/QQMarker.hs
@@ -28,7 +28,8 @@ qqMarker
      (antiqs :: Symbol)  -- antiquoted variables as a comma-separated list
      (line :: Nat)       -- line number of the quasiquotation
      args_tuple          -- uncoerced argument types
-     b.                  -- uncoerced result type
+     b                   -- uncoerced result type
+     m.
      ( tyres ~ Ty b
      , Coercibles args_tuple args_tys
      , Coercible b
@@ -40,8 +41,8 @@ qqMarker
   -> Proxy line
   -> args_tuple
   -> Proxy args_tys
-  -> (args_tuple -> IO b)
-  -> IO b
+  -> (args_tuple -> m b)
+  -> m b
 qqMarker = withFrozenCallStack $
     error
       "A quasiquotation marker was not removed. Please, report this as a bug."

--- a/src/common/Language/Java/Inline/Plugin.hs
+++ b/src/common/Language/Java/Inline/Plugin.hs
@@ -360,14 +360,14 @@ collectQQMarkers qqMarkerNames p0 = do
 
     expMarkers :: CoreExpr -> QQJavaM CoreExpr
     expMarkers (App (App (App (App (App (App (App (App (App (App (App (App (App
-                 (App (App (App (App (App (App (App (Var fid) _)
+                 (App (App (App (App (App (App (App (App (Var fid) _)
                  (Type (parseArgTys -> Just tyargs)))
                  (Type tyres))
                  (Type (LitTy (StrTyLit fs_input))))
                  (Type (LitTy (StrTyLit fs_mname))))
                  (Type (LitTy (StrTyLit fs_antiqs))))
                  (Type (LitTy (NumTyLit lineNumber))))
-                 _) _) _) _) _) _) _) _) _) _) args) _)
+                 _) _) _) _) _) _) _) _) _) _) _) args) _)
                  e
                )
         | elem (idName fid) qqMarkerNames = do

--- a/src/linear-types/Language/Java/Inline/Internal/QQMarker/Safe.hs
+++ b/src/linear-types/Language/Java/Inline/Internal/QQMarker/Safe.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -14,7 +15,6 @@ import Data.Proxy
 import GHC.Stack (HasCallStack, withFrozenCallStack)
 import GHC.TypeLits (Nat, Symbol)
 import qualified Language.Java.Safe as Safe
-import qualified System.IO.Linear as Linear
 
 -- | A function to indicate to the plugin the occurrence
 -- of java quasiquotations
@@ -28,7 +28,8 @@ qqMarker
      (antiqs :: Symbol)  -- antiquoted variables as a comma-separated list
      (line :: Nat)       -- line number of the quasiquotation
      args_tuple          -- uncoerced argument types
-     b.                  -- uncoerced result type
+     b                   -- uncoerced result type
+     m.
      ( tyres ~ Safe.Ty b
      , Coercibles args_tuple args_tys
      , Safe.Coercible b
@@ -40,8 +41,8 @@ qqMarker
   -> Proxy line
   -> args_tuple
   ->. Proxy args_tys
-  -> (args_tuple ->. Linear.IO b)
-  ->. Linear.IO b
+  -> (args_tuple ->. m b)
+  ->. m b
 qqMarker = withFrozenCallStack $
     error
       "A quasiquotation marker was not removed. Please, report this as a bug."

--- a/src/linear-types/Language/Java/Inline/Safe.hs
+++ b/src/linear-types/Language/Java/Inline/Safe.hs
@@ -45,12 +45,12 @@ module Language.Java.Inline.Safe
   , Java.loadJavaWrappers
   ) where
 
+import qualified Control.Monad.IO.Class.Linear as Linear
 import qualified Control.Monad.Linear as Linear
 import Language.Haskell.TH.Quote
 import qualified Language.Java.Inline.Internal as Java
 import qualified Language.Java.Inline.Internal.QQMarker.Safe as Safe
 import qualified Language.Java.Safe as Safe
-import qualified System.IO.Linear as Linear
 
 -- | Java code quasiquoter. Example:
 --
@@ -78,5 +78,5 @@ java = Java.javaWithConfig Java.QQConfig
     , Java.qqCallStatic = 'Safe.callStatic
     , Java.qqCoerce = 'Safe.coerce
     , Java.qqWrapMarker = \qExp ->
-        [| Linear.fromSystemIO loadJavaWrappers Linear.>> $qExp |]
+        [| Linear.liftIO loadJavaWrappers Linear.>> $qExp |]
     }

--- a/stack-linear.yaml
+++ b/stack-linear.yaml
@@ -44,7 +44,9 @@ extra-deps:
 - git: https://github.com/facundominguez/distributed-closure
   commit: a1c6780d8729a3e1091e18eddf0cb6dc977e325e
 - git: https://github.com/tweag/linear-base
-  commit: bdd1b9d0b7f24f9d1c6e27681238bbd3bc4d1e28
+  commit: 4d43dc099f6f1381b949ee29ac63ce3088597ab0
+- git: https://github.com/haskell/zlib
+  commit: 71f71a517755fd63978da50e21d1d340357ca910
 
 docker:
   enable: false


### PR DESCRIPTION
The linear interfaces were using `Linear.IO`, that might not be particularly easy to integrate in applications which use other monads.

I propose here a class to lift non-linear monads into linear monads. jni uses this to offer operations that run on any linear monad that can lift the non-linear `IO`.

```haskell
class (Linear.Monad m, NonLinear.Monad (LiftedM m)) => MonadLift m where
  type LiftedM m :: * -> *
  lift :: LiftedM m a -> m a
  liftU :: LiftedM m a -> m (Unrestricted a)
```

Thus, an application can provide an instance of `Linear.Monad` for any wrapper of a regularly looking monadic stack. e.g.

```haskell
data App a = App (ReaderT Env IO a)
  deriving (Monad, Functor, Applicative, MonadIO)

data LinearApp a = LinearApp (App a)

instance Linear.Monad LinearApp where
  ...

instance Linear.MonadLift LinearApp where
  type LiftedM LinearApp = App
  lift = LinearApp
  liftU = LinearApp . fmap Unrestricted
```