### PR TITLE
Require GHC 8.2 minimum

### DIFF
--- a/jvm/jvm.cabal
+++ b/jvm/jvm.cabal
@@ -27,7 +27,7 @@ library
   exposed-modules:
     Language.Java
   build-depends:
-    base >=4.7 && <5,
+    base >=4.10 && <5,
     bytestring >=0.10,
     constraints >=0.8,
     choice >=0.1,


### PR DESCRIPTION
We were previously only compatible with 8.0.2, not 8.0.1 due to an
upstream bug. To avoid CPP, we just drop the 8.x series, which by this
point is old anyways.