### PR TITLE
Make the singletons of arguments to foreign calls depend only on types.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
           name: Build dependencies
           command: |
             . env-linear.sh
-            stack --no-terminal build --only-dependencies --prefetch --test -j4 jni jvm inline-java
+            stack --no-terminal build --only-dependencies --prefetch --test -j1 jni jvm inline-java
       - save_cache:
           key: inline-java-stack-linear-dependencies-{{ arch }}-{{ checksum "/tmp/stack-deps" }}
           paths:
@@ -130,7 +130,7 @@ jobs:
           name: Build project
           command: |
             . env-linear.sh
-            stack --no-terminal build -j4 --pedantic --test --no-run-tests --no-run-benchmarks inline-java
+            stack --no-terminal build -j1 --pedantic --test --no-run-tests --no-run-benchmarks inline-java
       - run:
           name: Test
           command: |

--- a/benchmarks/micro/Main.hs
+++ b/benchmarks/micro/Main.hs
@@ -48,9 +48,9 @@ benchCallbacks =
         ]
       , bgroup "jvm"
         [ bench "return" $ withLocalFrame 1 $
-            void @_ @JObject $ call fun "apply" [coerce obj, coerce (JNI.upcast jstr)]
+            void @_ @JObject $ call fun "apply" (obj, JNI.upcast jstr)
         , bench "no-callback" $ withLocalFrame 1 $
-            void @_ @JString $ call jstr "concat" [coerce jstr2]
+            void @_ @JString $ call jstr "concat" jstr2
         ]
       ]
   where

--- a/jvm-batching/src/main/haskell/Language/Java/Batching.hs
+++ b/jvm-batching/src/main/haskell/Language/Java/Batching.hs
@@ -322,9 +322,7 @@ reflectArrayBatch reflectB getLength concatenate vecs = do
     bigvec <- concatenate $ V.toList vecs
     jvec <- reflectB bigvec
     jends <- reflect ends
-    generic <$> Language.Java.new [ coerce (upcast jvec)
-                                  , coerce (upcast jends)
-                                  ]
+    generic <$> Language.Java.new (upcast jvec, upcast jends)
 
 withStatic [d|
   instance Batchable Bool where

--- a/jvm/CHANGELOG.md
+++ b/jvm/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 * Benchmarks for arrays and direct buffer operations
 * An interface based on linear types (https://github.com/tweag/inline-java/pull/127)
 * An abstract monad to use in the safe interfaces (https://github.com/tweag/inline-java/pull/128)
+* Caching of MethodIDs (https://github.com/tweag/inline-java/pull/133)
 
 ### Removed
 

--- a/jvm/README.md
+++ b/jvm/README.md
@@ -32,7 +32,7 @@ main = withJVM [] $ do
     callStatic
       (classOf (undefined :: JOptionPane))
       "showMessageDialog"
-      [JObject nullComponent, JObject (upcast message)]
+      (nullComponent, upcast message)
   where
     nullComponent :: J ('Class "java.awt.Component")
     nullComponent = jnull

--- a/jvm/benchmarks/Main.hs
+++ b/jvm/benchmarks/Main.hs
@@ -28,7 +28,7 @@ newtype Box a = Box { unBox :: a }
 instance NFData (Box a) where rnf (Box a) = seq a ()
 
 jabs :: Int32 -> IO Int32
-jabs x = callStatic "java.lang.Math" "abs" [coerce x]
+jabs x = callStatic "java.lang.Math" "abs" x
 
 jniAbs :: JClass -> JMethodID -> Int32 -> IO Int32
 jniAbs klass method x = callStaticIntMethod klass method [coerce x]
@@ -36,13 +36,13 @@ jniAbs klass method x = callStaticIntMethod klass method [coerce x]
 intValue :: Int32 -> IO Int32
 intValue x = do
     jx <- reflect x
-    call jx "intValue" []
+    call jx "intValue" ()
 
 compareTo :: Int32 -> Int32 -> IO Int32
 compareTo x y = do
     jx <- reflect x
     jy <- reflect y
-    call jx "compareTo" [coerce jy]
+    call jx "compareTo" jy
 
 incrHaskell :: Int32 -> IO Int32
 incrHaskell x = return (x + 1)
@@ -63,7 +63,7 @@ benchCalls =
             )
             (\_ _ -> void (popLocalFrame jnull)) $
             \(Box jStringInteger) -> do
-              _ <- callStatic "java.lang.Integer" "valueOf" [coerce jStringInteger]
+              _ <- callStatic "java.lang.Integer" "valueOf" jStringInteger
                  :: IO (J ('Class "java.lang.Integer"))
               return ()
         , bench "jni static method call: unboxed single arg / unboxed return" $ nfIO $ jniAbs klass method 1
@@ -105,7 +105,7 @@ benchCalls =
 
 benchRefs :: Benchmark
 benchRefs =
-    env (Box <$> new []) $ \ ~(Box (jobj :: JObject)) ->
+    env (Box <$> new ()) $ \ ~(Box (jobj :: JObject)) ->
     bgroup "References"
     [ bench "local reference" $ nfIO $ do
         _ <- newLocalRef jobj
@@ -149,14 +149,14 @@ benchNew =
         (pushLocalFrame . (2*) . fromIntegral)
         (\_ _ -> void (popLocalFrame jnull)) $
         \() -> do
-          _ <- new [JInt 2] :: IO (J ('Class "java.lang.Integer"))
+          _ <- new (2 :: Int32) :: IO (J ('Class "java.lang.Integer"))
           return ()
     , bench "Integer.valueOf" $
       perBatchEnvWithCleanup
         (pushLocalFrame . (2*) . fromIntegral)
         (\_ _ -> void (popLocalFrame jnull)) $
         \() -> do
-          _ <- callStatic "java.lang.Integer" "valueOf" [JInt 2]
+          _ <- callStatic "java.lang.Integer" "valueOf" (2 :: Int32)
                  :: IO (J ('Class "java.lang.Integer"))
           return ()
     , envWithCleanup allocTextPtr freeTextPtr $ \ ~(Box (ptr, len)) ->

--- a/jvm/src/common/Language/Java/Unsafe.hs
+++ b/jvm/src/common/Language/Java/Unsafe.hs
@@ -16,10 +16,10 @@
 --   deriving (J.Coercible, J.Interpretation, J.Reify, J.Reflect)
 --
 -- clone :: Object -> IO Object
--- clone obj = J.'call' obj "clone" []
+-- clone obj = J.'call' obj "clone" ()
 --
 -- equals :: Object -> Object -> IO Bool
--- equals obj1 obj2 = J.'call' obj1 "equals" ['jvalue' obj2]
+-- equals obj1 obj2 = J.'call' obj1 "equals" obj2
 --
 -- ...
 -- @
@@ -101,6 +101,7 @@ import qualified Data.Coerce as Coerce
 import Data.Constraint (Dict(..))
 import Data.Int
 import Data.Proxy (Proxy(..))
+import Data.Singletons (SomeSing(..))
 import Data.Typeable (Typeable, TypeRep, typeOf)
 import Data.Word
 import Data.ByteString (ByteString)
@@ -280,6 +281,129 @@ classOf
   -> JNI.String
 classOf x = JNI.fromChars (symbolVal (Proxy :: Proxy sym)) `const` coerce x
 
+-- | A class to collect the arguments of a function call and the singletons of
+-- their types.
+--
+-- The instances of @JNIArguments@ allow @xs@ to be of the form:
+--
+-- > (Coercible x1, ... , Coercible xn) => (x1, ... , xn)
+--
+-- This class allows computing MethodIDs of JNI calls exclusively
+-- from types, which enables caching MethodIDs for multiple
+-- invocations of a method.
+--
+class JNIArguments xs where
+  -- | Singletons of the argument types of a JNICall.
+  --
+  -- > sings (Proxy @(x1, ... , xn)) =
+  -- >   SomeSing (sing :: Sing x0), ..., SomeSing (sing :: Sing xn)]
+  --
+  sings :: Proxy xs -> [SomeSing JType]
+
+  -- |
+  -- > jvalues (x1, ... ,xn) = [coerce x1, ... , coerce xn]
+  --
+  jvalues :: xs -> [JValue]
+
+instance JNIArguments () where
+  sings _ = []
+  jvalues _ = []
+
+instance {-# OVERLAPPABLE #-} Coercible x => JNIArguments x where
+  sings _ = [SomeSing (sing :: Sing (Ty x))]
+  jvalues x = [coerce x]
+
+instance (Coercible x1, Coercible x2) => JNIArguments (x1, x2) where
+  sings _ = [SomeSing (sing :: Sing (Ty x1)), SomeSing (sing :: Sing (Ty x2))]
+  jvalues (x1, x2) = [coerce x1, coerce x2]
+
+instance
+    ( Coercible x1
+    , Coercible x2
+    , Coercible x3
+    ) => JNIArguments (x1, x2, x3) where
+  sings _ =
+    [ SomeSing (sing :: Sing (Ty x1))
+    , SomeSing (sing :: Sing (Ty x2))
+    , SomeSing (sing :: Sing (Ty x3))
+    ]
+  jvalues (x1, x2, x3) = [coerce x1, coerce x2, coerce x3]
+
+instance
+    ( Coercible x1
+    , Coercible x2
+    , Coercible x3
+    , Coercible x4
+    ) => JNIArguments (x1, x2, x3, x4) where
+  sings _ =
+    [ SomeSing (sing :: Sing (Ty x1))
+    , SomeSing (sing :: Sing (Ty x2))
+    , SomeSing (sing :: Sing (Ty x3))
+    , SomeSing (sing :: Sing (Ty x4))
+    ]
+  jvalues (x1, x2, x3, x4) = [coerce x1, coerce x2, coerce x3, coerce x4]
+
+instance
+    ( Coercible x1
+    , Coercible x2
+    , Coercible x3
+    , Coercible x4
+    , Coercible x5
+    ) => JNIArguments (x1, x2, x3, x4, x5) where
+  sings _ =
+    [ SomeSing (sing :: Sing (Ty x1))
+    , SomeSing (sing :: Sing (Ty x2))
+    , SomeSing (sing :: Sing (Ty x3))
+    , SomeSing (sing :: Sing (Ty x4))
+    , SomeSing (sing :: Sing (Ty x5))
+    ]
+  jvalues (x1, x2, x3, x4, x5) = [coerce x1, coerce x2, coerce x3, coerce x4, coerce x5]
+
+instance
+    ( Coercible x1
+    , Coercible x2
+    , Coercible x3
+    , Coercible x4
+    , Coercible x5
+    , Coercible x6
+    ) => JNIArguments (x1, x2, x3, x4, x5, x6) where
+  sings _ =
+    [ SomeSing (sing :: Sing (Ty x1))
+    , SomeSing (sing :: Sing (Ty x2))
+    , SomeSing (sing :: Sing (Ty x3))
+    , SomeSing (sing :: Sing (Ty x4))
+    , SomeSing (sing :: Sing (Ty x5))
+    , SomeSing (sing :: Sing (Ty x6))
+    ]
+  jvalues (x1, x2, x3, x4, x5, x6) =
+    [coerce x1, coerce x2, coerce x3, coerce x4, coerce x5, coerce x6]
+
+instance
+    ( Coercible x1
+    , Coercible x2
+    , Coercible x3
+    , Coercible x4
+    , Coercible x5
+    , Coercible x6
+    , Coercible x7
+    ) => JNIArguments (x1, x2, x3, x4, x5, x6, x7) where
+  sings _ =
+    [ SomeSing (sing :: Sing (Ty x1))
+    , SomeSing (sing :: Sing (Ty x2))
+    , SomeSing (sing :: Sing (Ty x3))
+    , SomeSing (sing :: Sing (Ty x4))
+    , SomeSing (sing :: Sing (Ty x5))
+    , SomeSing (sing :: Sing (Ty x6))
+    , SomeSing (sing :: Sing (Ty x7))
+    ]
+  jvalues (x1, x2, x3, x4, x5, x6, x7) =
+    [coerce x1, coerce x2, coerce x3, coerce x4, coerce x5, coerce x6, coerce x7]
+
+type family JNIResult t :: * where
+  JNIResult (IO a) = a
+  JNIResult (a -> b) = JNIResult b
+  JNIResult a = ()
+
 -- | Creates a new instance of the class whose name is resolved from the return
 -- type. For instance,
 --
@@ -288,15 +412,16 @@ classOf x = JNI.fromChars (symbolVal (Proxy :: Proxy sym)) `const` coerce x
 --    return x
 -- @
 new
-  :: forall a sym.
+  :: forall a sym args.
      ( Ty a ~ 'Class sym
      , Coerce.Coercible a (J ('Class sym))
      , Coercible a
+     , JNIArguments args
      )
-  => [JValue]
+  => args
   -> IO a
 {-# INLINE new #-}
-new args = Coerce.coerce <$> newJ @sym args
+new args = Coerce.coerce <$> newJ @sym (sings @args Proxy) (jvalues args)
 
 -- | Creates a new Java array of the given size. The type of the elements
 -- of the resulting array is determined by the return type a call to
@@ -357,26 +482,42 @@ toArray xs = do
 -- appropriately on the class instance and/or on the arguments to invoke the
 -- right method.
 call
-  :: forall a b ty1 ty2. (ty1 ~ Ty a, ty2 ~ Ty b, IsReferenceType ty1, Coercible a, Coercible b, Coerce.Coercible a (J ty1))
+  :: forall a args b.
+    ( IsReferenceType (Ty a)
+    , Coercible a
+    , Coercible b
+    , Coerce.Coercible a (J (Ty a))
+    , JNIArguments args
+    )
   => a -- ^ Any object or value 'Coercible' to one
   -> JNI.String -- ^ Method name
-  -> [JValue] -- ^ Arguments
+  -> args -- ^ Arguments
   -> IO b
 {-# INLINE call #-}
 call obj mname args =
-    unsafeUncoerce <$>
-      callToJValue (sing :: Sing ty2) (Coerce.coerce obj :: J ty1) mname args
+    unsafeUncoerce <$> callToJValue
+        (sing :: Sing (Ty b))
+        (Coerce.coerce obj :: J (Ty a))
+        mname
+        (sings @args Proxy)
+        (jvalues args)
 
 -- | Same as 'call', but for static methods.
 callStatic
-  :: forall a ty. (ty ~ Ty a, Coercible a)
+  :: forall args b. (JNIArguments args, Coercible b)
   => JNI.String -- ^ Class name
   -> JNI.String -- ^ Method name
-  -> [JValue] -- ^ Arguments
-  -> IO a
+  -> args -- ^ Arguments
+  -> IO b
 {-# INLINE callStatic #-}
 callStatic cname mname args =
-    unsafeUncoerce <$> callStaticToJValue (sing :: Sing ty) cname mname args
+    unsafeUncoerce <$>
+      callStaticToJValue
+        (sing :: Sing (Ty b))
+        cname
+        mname
+        (sings @args Proxy)
+        (jvalues args)
 
 -- | Get a static field.
 getStaticField
@@ -469,7 +610,7 @@ withStatic [d|
   -- We take an arbitrary serializable type to represent it.
   instance Interpretation () where type Interp () = 'Class "java.lang.Short"
   instance Reify () where reify _ = return ()
-  instance Reflect () where reflect () = new [JShort 0]
+  instance Reflect () where reflect () = new (0 :: Int16)
 
   instance Interpretation ByteString where
     type Interp ByteString = 'Array ('Prim "byte")
@@ -504,7 +645,7 @@ withStatic [d|
         callBooleanMethod jobj method []
 
   instance Reflect Bool where
-    reflect x = new [JBoolean (fromIntegral (fromEnum x))]
+    reflect = new
 
   instance Interpretation CChar where
     type Interp CChar = 'Class "java.lang.Byte"
@@ -520,7 +661,7 @@ withStatic [d|
         callByteMethod jobj method []
 
   instance Reflect CChar where
-    reflect x = Language.Java.Unsafe.new [JByte x]
+    reflect = Language.Java.Unsafe.new
 
   instance Interpretation Int16 where
     type Interp Int16 = 'Class "java.lang.Short"
@@ -536,7 +677,7 @@ withStatic [d|
         callShortMethod jobj method []
 
   instance Reflect Int16 where
-    reflect x = new [JShort x]
+    reflect = new
 
   instance Interpretation Int32 where
     type Interp Int32 = 'Class "java.lang.Integer"
@@ -552,7 +693,7 @@ withStatic [d|
         callIntMethod jobj method []
 
   instance Reflect Int32 where
-    reflect x = new [JInt x]
+    reflect = new
 
   instance Interpretation Int64 where
     type Interp Int64 = 'Class "java.lang.Long"
@@ -568,7 +709,7 @@ withStatic [d|
         callLongMethod jobj method []
 
   instance Reflect Int64 where
-    reflect x = new [JLong x]
+    reflect = new
 
   instance Interpretation Word16 where
     type Interp Word16 = 'Class "java.lang.Character"
@@ -584,7 +725,7 @@ withStatic [d|
         fromIntegral <$> callCharMethod jobj method []
 
   instance Reflect Word16 where
-    reflect x = new [JChar x]
+    reflect = new
 
   instance Interpretation Double where
     type Interp Double = 'Class "java.lang.Double"
@@ -600,7 +741,7 @@ withStatic [d|
         callDoubleMethod jobj method []
 
   instance Reflect Double where
-    reflect x = new [JDouble x]
+    reflect = new
 
   instance Interpretation Float where
     type Interp Float = 'Class "java.lang.Float"
@@ -616,7 +757,7 @@ withStatic [d|
         callFloatMethod jobj method []
 
   instance Reflect Float where
-    reflect x = new [JFloat x]
+    reflect = new
 
   instance Interpretation Text where
     type Interp Text = 'Class "java.lang.String"

--- a/jvm/src/linear-types/Language/Java/Safe.hs
+++ b/jvm/src/linear-types/Language/Java/Safe.hs
@@ -19,10 +19,10 @@
 --   deriving (J.Coercible, J.Interpretation, J.Reify, J.Reflect)
 --
 -- clone :: Object ->. Linear.IO Object
--- clone obj = J.'call' obj "clone" []
+-- clone obj = J.'call' obj "clone" ()
 --
 -- equals :: Object ->. Object ->. Linear.IO Bool
--- equals obj1 obj2 = J.'call' obj1 "equals" ['jvalue' obj2]
+-- equals obj1 obj2 = J.'call' obj1 "equals" obj2
 --
 -- ...
 -- @
@@ -37,6 +37,7 @@
 -- class and method lookups, for performance. This memoization is safe only when
 -- no new named classes are defined at runtime.
 
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
@@ -49,6 +50,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StaticPointers #-}
 {-# LANGUAGE TypeApplications #-}
@@ -90,7 +92,7 @@ import Data.ByteString (ByteString)
 import qualified Data.Choice as Choice
 import qualified Data.Coerce as Coerce
 import Data.Int
-import Data.Singletons (SingI(..))
+import Data.Singletons (SingI(..), SomeSing(..))
 import Data.Text (Text)
 import Data.Typeable
 import qualified Data.Unrestricted.Linear as Unrestricted
@@ -215,6 +217,124 @@ classOf
 classOf = Unsafe.toLinear $ \x -> (,) x $
   JNI.fromChars (symbolVal (Proxy :: Proxy sym)) `const` coerce x
 
+-- | A class to collect the arguments of a function call and the singletons of
+-- their types.
+--
+-- The instances of @JNIArguments@ allow @xs@ to be of the form:
+--
+-- > (Coercible x1, ... , Coercible xn) => (x1, ... , xn)
+--
+-- This class allows computing MethodIDs of JNI calls exclusively
+-- from types, which enables caching MethodIDs for multiple
+-- invocations of a method.
+--
+class JNIArguments xs where
+  -- | Singletons of the argument types of a JNICall.
+  --
+  -- > sings (Proxy @(x1, ... , xn)) =
+  -- >  [SomeSing (sing :: Sing x0), ..., SomeSing (sing :: Sing xn)]
+  --
+  sings :: Proxy xs -> [SomeSing JType]
+
+  -- |
+  -- > jvalues (x1, ... ,xn) = [coerce x1, ... , coerce xn]
+  --
+  jvalues :: xs -> [JValue]
+
+instance JNIArguments () where
+  sings _ = []
+  jvalues _ = []
+
+instance {-# OVERLAPPABLE #-} Coercible x => JNIArguments x where
+  sings _ = [SomeSing (sing :: Sing (Ty x))]
+  jvalues x = [coerce x]
+
+instance (Coercible x1, Coercible x2) => JNIArguments (x1, x2) where
+  sings _ = [SomeSing (sing :: Sing (Ty x1)), SomeSing (sing :: Sing (Ty x2))]
+  jvalues (x1, x2) = [coerce x1, coerce x2]
+
+instance
+    ( Coercible x1
+    , Coercible x2
+    , Coercible x3
+    ) => JNIArguments (x1, x2, x3) where
+  sings _ =
+    [ SomeSing (sing :: Sing (Ty x1))
+    , SomeSing (sing :: Sing (Ty x2))
+    , SomeSing (sing :: Sing (Ty x3))
+    ]
+  jvalues (x1, x2, x3) = [coerce x1, coerce x2, coerce x3]
+
+instance
+    ( Coercible x1
+    , Coercible x2
+    , Coercible x3
+    , Coercible x4
+    ) => JNIArguments (x1, x2, x3, x4) where
+  sings _ =
+    [ SomeSing (sing :: Sing (Ty x1))
+    , SomeSing (sing :: Sing (Ty x2))
+    , SomeSing (sing :: Sing (Ty x3))
+    , SomeSing (sing :: Sing (Ty x4))
+    ]
+  jvalues (x1, x2, x3, x4) = [coerce x1, coerce x2, coerce x3, coerce x4]
+
+instance
+    ( Coercible x1
+    , Coercible x2
+    , Coercible x3
+    , Coercible x4
+    , Coercible x5
+    ) => JNIArguments (x1, x2, x3, x4, x5) where
+  sings _ =
+    [ SomeSing (sing :: Sing (Ty x1))
+    , SomeSing (sing :: Sing (Ty x2))
+    , SomeSing (sing :: Sing (Ty x3))
+    , SomeSing (sing :: Sing (Ty x4))
+    , SomeSing (sing :: Sing (Ty x5))
+    ]
+  jvalues (x1, x2, x3, x4, x5) = [coerce x1, coerce x2, coerce x3, coerce x4, coerce x5]
+
+instance
+    ( Coercible x1
+    , Coercible x2
+    , Coercible x3
+    , Coercible x4
+    , Coercible x5
+    , Coercible x6
+    ) => JNIArguments (x1, x2, x3, x4, x5, x6) where
+  sings _ =
+    [ SomeSing (sing :: Sing (Ty x1))
+    , SomeSing (sing :: Sing (Ty x2))
+    , SomeSing (sing :: Sing (Ty x3))
+    , SomeSing (sing :: Sing (Ty x4))
+    , SomeSing (sing :: Sing (Ty x5))
+    , SomeSing (sing :: Sing (Ty x6))
+    ]
+  jvalues (x1, x2, x3, x4, x5, x6) =
+    [coerce x1, coerce x2, coerce x3, coerce x4, coerce x5, coerce x6]
+
+instance
+    ( Coercible x1
+    , Coercible x2
+    , Coercible x3
+    , Coercible x4
+    , Coercible x5
+    , Coercible x6
+    , Coercible x7
+    ) => JNIArguments (x1, x2, x3, x4, x5, x6, x7) where
+  sings _ =
+    [ SomeSing (sing :: Sing (Ty x1))
+    , SomeSing (sing :: Sing (Ty x2))
+    , SomeSing (sing :: Sing (Ty x3))
+    , SomeSing (sing :: Sing (Ty x4))
+    , SomeSing (sing :: Sing (Ty x5))
+    , SomeSing (sing :: Sing (Ty x6))
+    , SomeSing (sing :: Sing (Ty x7))
+    ]
+  jvalues (x1, x2, x3, x4, x5, x6, x7) =
+    [coerce x1, coerce x2, coerce x3, coerce x4, coerce x5, coerce x6, coerce x7]
+
 -- | Creates a new instance of the class whose name is resolved from the return
 -- type. For instance,
 --
@@ -223,14 +343,15 @@ classOf = Unsafe.toLinear $ \x -> (,) x $
 --    return x
 -- @
 new
-  :: forall a sym m.
-     (Ty a ~ 'Class sym, Coercible a, MonadIO m)
-  => [JValue]
+  :: forall a sym m args.
+     (Ty a ~ 'Class sym, Coercible a, MonadIO m, JNIArguments args)
+  => args
   ->. m a
 {-# INLINE new #-}
-new = Unsafe.toLinear $ \args -> fmap unsafeUncoerce $ liftIO Prelude.$
-    JObject . J <$> Java.newJ @sym (toJNIJValues args)
-      Prelude.<* deleteLinearJObjects args
+new = Unsafe.toLinear $ \args -> fmap unsafeUncoerce $ liftIO Prelude.$ do
+    let jargs = jvalues args
+    JObject . J <$> Java.newJ @sym (sings @args Proxy) (toJNIJValues jargs)
+      Prelude.<* deleteLinearJObjects jargs
 
 -- | Creates a new Java array of the given size. The type of the elements
 -- of the resulting array is determined by the return type a call to
@@ -264,7 +385,7 @@ toArray = Unsafe.toLinear $ \xs ->
 -- appropriately on the class instance and/or on the arguments to invoke the
 -- right method.
 call
-  :: forall a b ty1 ty2 m.
+  :: forall a b ty1 ty2 m args.
      ( ty1 ~ Ty a
      , ty2 ~ Ty b
      , IsReferenceType ty1
@@ -272,18 +393,24 @@ call
      , Coercible b
      , Coerce.Coercible a (J ty1)
      , MonadIO m
+     , JNIArguments args
      )
   => a -- ^ Any object or value 'Coercible' to one
   ->. JNI.String -- ^ Method name
-  -> [JValue] -- ^ Arguments
+  -> args -- ^ Arguments
   ->. m b
 {-# INLINE call #-}
-call = Unsafe.toLinear $ \obj mname -> Unsafe.toLinear $ \args ->
+call = Unsafe.toLinear $ \obj mname -> Unsafe.toLinear $ \args -> do
+    let jargs = jvalues args
     liftIO Prelude.$ strictUnsafeUncoerce Prelude.$ do
       fromJNIJValue <$>
         Java.callToJValue @ty1
-          (sing :: Sing ty1) (Coerce.coerce obj) mname (toJNIJValues args)
-        Prelude.<* deleteLinearJObjects args
+          (sing :: Sing ty1)
+          (Coerce.coerce obj)
+          mname
+          (sings @args Proxy)
+          (toJNIJValues jargs)
+        Prelude.<* deleteLinearJObjects jargs
 
 strictUnsafeUncoerce :: Coercible a => IO JValue -> IO a
 strictUnsafeUncoerce m = m Prelude.>>= \x -> evaluate (unsafeUncoerce x)
@@ -295,17 +422,19 @@ fromJNIJValue = \case
 
 -- | Same as 'call', but for static methods.
 callStatic
-  :: forall a ty m. (ty ~ Ty a, Coercible a, MonadIO m)
+  :: forall a args m. (MonadIO m, JNIArguments args, Coercible a)
   => JNI.String -- ^ Class name
   -> JNI.String -- ^ Method name
-  -> [JValue] -- ^ Arguments
+  -> args
   ->. m a
 {-# INLINE callStatic #-}
 callStatic cname mname = Unsafe.toLinear $ \args ->
-    liftIO Prelude.$ strictUnsafeUncoerce Prelude.$
+    liftIO Prelude.$ strictUnsafeUncoerce Prelude.$ do
+      let jargs = jvalues args
       fromJNIJValue <$>
-      Java.callStaticToJValue (sing :: Sing ty) cname mname (toJNIJValues args)
-        Prelude.<* deleteLinearJObjects args
+        Java.callStaticToJValue
+          (sing :: Sing (Ty a)) cname mname (sings @args Proxy) (toJNIJValues jargs)
+        Prelude.<* deleteLinearJObjects jargs
 
 -- | Get a static field.
 getStaticField

--- a/jvm/tests/Language/JavaSpec.hs
+++ b/jvm/tests/Language/JavaSpec.hs
@@ -19,12 +19,12 @@ spec = do
     describe "callStatic" $ do
       it "can call double-returning static functions" $ do
         jstr <- reflect ("1.2345" :: Text)
-        callStatic "java.lang.Double" "parseDouble" [coerce jstr]
+        callStatic "java.lang.Double" "parseDouble" jstr
           `shouldReturn` (1.2345 :: Double)
 
       it "can call int-returning static functions" $ do
         jstr <- reflect ("12345" :: Text)
-        callStatic "java.lang.Integer" "parseInt" [coerce jstr]
+        callStatic "java.lang.Integer" "parseInt" jstr
           `shouldReturn` (12345 :: Int32)
 
       it "can call String-returning static functions" $ do
@@ -32,7 +32,7 @@ spec = do
           callStatic
             "java.lang.Integer"
             "toString"
-            [coerce (12345 :: Int32)]
+            (12345 :: Int32)
         reify jstr `shouldReturn` ("12345" :: Text)
 
       it "can get static fields" $ do
@@ -42,31 +42,31 @@ spec = do
       it "can get enum values" $ do
         monday :: J ('Class "java.time.DayOfWeek") <-
           getStaticField "java.time.DayOfWeek" "MONDAY"
-        call monday "getValue" []
+        call monday "getValue" ()
           `shouldReturn` (1 :: Int32)
 
       it "short doesn't under- or overflow" $ do
         maxshort <- reflect (Text.pack (show (maxBound :: Int16)))
         minshort <- reflect (Text.pack (show (minBound :: Int16)))
-        callStatic "java.lang.Short" "parseShort" [coerce maxshort]
+        callStatic "java.lang.Short" "parseShort" maxshort
           `shouldReturn` (maxBound :: Int16)
-        callStatic "java.lang.Short" "parseShort" [coerce minshort]
+        callStatic "java.lang.Short" "parseShort" minshort
           `shouldReturn` (minBound :: Int16)
 
       it "int doesn't under- or overflow" $ do
         maxint <- reflect (Text.pack (show (maxBound :: Int32)))
         minint <- reflect (Text.pack (show (minBound :: Int32)))
-        callStatic "java.lang.Integer" "parseInt" [coerce maxint]
+        callStatic "java.lang.Integer" "parseInt" maxint
           `shouldReturn` (maxBound :: Int32)
-        callStatic "java.lang.Integer" "parseInt" [coerce minint]
+        callStatic "java.lang.Integer" "parseInt" minint
           `shouldReturn` (minBound :: Int32)
 
       it "long doesn't under- or overflow" $ do
         maxlong <- reflect (Text.pack (show (maxBound :: Int64)))
         minlong <- reflect (Text.pack (show (minBound :: Int64)))
-        callStatic "java.lang.Long" "parseLong" [coerce maxlong]
+        callStatic "java.lang.Long" "parseLong" maxlong
           `shouldReturn` (maxBound :: Int64)
-        callStatic "java.lang.Long" "parseLong" [coerce minlong]
+        callStatic "java.lang.Long" "parseLong" minlong
           `shouldReturn` (minBound :: Int64)
 
     describe "newArray" $ do
@@ -86,5 +86,5 @@ spec = do
       -- Applications need extra conversions if the following doesn't hold.
       it "can get Integer when Long is expected" $ do
         let i = maxBound :: Int32
-        j <- new [coerce i] :: IO (J ('Class "java.lang.Integer"))
+        j <- new i :: IO (J ('Class "java.lang.Integer"))
         reify (unsafeCast j) `shouldReturn` (fromIntegral i :: Int64)

--- a/src/common/Language/Java/Inline/Unsafe.hs
+++ b/src/common/Language/Java/Inline/Unsafe.hs
@@ -85,6 +85,5 @@ java :: QuasiQuoter
 java = javaWithConfig QQConfig
     { qqMarker = 'QQMarker.qqMarker
     , qqCallStatic = 'callStatic
-    , qqCoerce = 'coerce
     , qqWrapMarker = \qExp -> [| loadJavaWrappers >> $qExp |]
     }

--- a/src/linear-types/Language/Java/Inline/Safe.hs
+++ b/src/linear-types/Language/Java/Inline/Safe.hs
@@ -76,7 +76,6 @@ java :: QuasiQuoter
 java = Java.javaWithConfig Java.QQConfig
     { Java.qqMarker = 'Safe.qqMarker
     , Java.qqCallStatic = 'Safe.callStatic
-    , Java.qqCoerce = 'Safe.coerce
     , Java.qqWrapMarker = \qExp ->
         [| Linear.liftIO loadJavaWrappers Linear.>> $qExp |]
     }


### PR DESCRIPTION
We introduce here a type class that provides the singletons of arguments as computed from their types but not their values. This makes possible caching the MethodID for multiple invocations.