### PR TITLE
jvm: make call* variadic in the unsafe interface

### DIFF
--- a/benchmarks/micro/Main.hs
+++ b/benchmarks/micro/Main.hs
@@ -48,9 +48,9 @@ benchCallbacks =
         ]
       , bgroup "jvm"
         [ bench "return" $ withLocalFrame 1 $
-            void @_ @JObject $ call fun "apply" [coerce obj, coerce (JNI.upcast jstr)]
+            void @_ @JObject $ call fun "apply" obj (JNI.upcast jstr)
         , bench "no-callback" $ withLocalFrame 1 $
-            void @_ @JString $ call jstr "concat" [coerce jstr2]
+            void @_ @JString $ call jstr "concat" jstr2
         ]
       ]
   where

--- a/jvm-batching/src/main/haskell/Language/Java/Batching.hs
+++ b/jvm-batching/src/main/haskell/Language/Java/Batching.hs
@@ -322,9 +322,7 @@ reflectArrayBatch reflectB getLength concatenate vecs = do
     bigvec <- concatenate $ V.toList vecs
     jvec <- reflectB bigvec
     jends <- reflect ends
-    generic <$> Language.Java.new [ coerce (upcast jvec)
-                                  , coerce (upcast jends)
-                                  ]
+    generic <$> Language.Java.new (upcast jvec) (upcast jends)
 
 withStatic [d|
   instance Batchable Bool where

--- a/jvm/BUILD.bazel
+++ b/jvm/BUILD.bazel
@@ -15,6 +15,7 @@ haskell_library(
         "@stackage//:distributed-closure",
         "@stackage//:exceptions",
         "@stackage//:singletons",
+        "@stackage//:template-haskell",
         "@stackage//:text",
         "@stackage//:vector",
     ],

--- a/jvm/CHANGELOG.md
+++ b/jvm/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Next release
 
+### Changed
+
+* `call`, `callStatic` and `new` are now variadic. Instead of packing
+  arguments to methods and to constructors into a list, the arguments
+  can now be passed directly. This is a breaking change.
+
 ### Added
 
 * Support for ghc-8.9

--- a/jvm/benchmarks/Main.hs
+++ b/jvm/benchmarks/Main.hs
@@ -28,7 +28,7 @@ newtype Box a = Box { unBox :: a }
 instance NFData (Box a) where rnf (Box a) = seq a ()
 
 jabs :: Int32 -> IO Int32
-jabs x = callStatic "java.lang.Math" "abs" [coerce x]
+jabs x = callStatic "java.lang.Math" "abs" x
 
 jniAbs :: JClass -> JMethodID -> Int32 -> IO Int32
 jniAbs klass method x = callStaticIntMethod klass method [coerce x]
@@ -36,13 +36,13 @@ jniAbs klass method x = callStaticIntMethod klass method [coerce x]
 intValue :: Int32 -> IO Int32
 intValue x = do
     jx <- reflect x
-    call jx "intValue" []
+    call jx "intValue"
 
 compareTo :: Int32 -> Int32 -> IO Int32
 compareTo x y = do
     jx <- reflect x
     jy <- reflect y
-    call jx "compareTo" [coerce jy]
+    call jx "compareTo" jy
 
 incrHaskell :: Int32 -> IO Int32
 incrHaskell x = return (x + 1)
@@ -63,7 +63,7 @@ benchCalls =
             )
             (\_ _ -> void (popLocalFrame jnull)) $
             \(Box jStringInteger) -> do
-              _ <- callStatic "java.lang.Integer" "valueOf" [coerce jStringInteger]
+              _ <- callStatic "java.lang.Integer" "valueOf" jStringInteger
                  :: IO (J ('Class "java.lang.Integer"))
               return ()
         , bench "jni static method call: unboxed single arg / unboxed return" $ nfIO $ jniAbs klass method 1
@@ -105,7 +105,7 @@ benchCalls =
 
 benchRefs :: Benchmark
 benchRefs =
-    env (Box <$> new []) $ \ ~(Box (jobj :: JObject)) ->
+    env (Box <$> new) $ \ ~(Box (jobj :: JObject)) ->
     bgroup "References"
     [ bench "local reference" $ nfIO $ do
         _ <- newLocalRef jobj
@@ -149,14 +149,14 @@ benchNew =
         (pushLocalFrame . (2*) . fromIntegral)
         (\_ _ -> void (popLocalFrame jnull)) $
         \() -> do
-          _ <- new [JInt 2] :: IO (J ('Class "java.lang.Integer"))
+          _ <- new (2 :: Int32) :: IO (J ('Class "java.lang.Integer"))
           return ()
     , bench "Integer.valueOf" $
       perBatchEnvWithCleanup
         (pushLocalFrame . (2*) . fromIntegral)
         (\_ _ -> void (popLocalFrame jnull)) $
         \() -> do
-          _ <- callStatic "java.lang.Integer" "valueOf" [JInt 2]
+          _ <- callStatic "java.lang.Integer" "valueOf" (2 :: Int32)
                  :: IO (J ('Class "java.lang.Integer"))
           return ()
     , envWithCleanup allocTextPtr freeTextPtr $ \ ~(Box (ptr, len)) ->

--- a/jvm/jvm.cabal
+++ b/jvm/jvm.cabal
@@ -37,6 +37,7 @@ library
     exceptions >=0.8,
     jni >=0.4.0 && <0.7,
     text >=1.2,
+    template-haskell,
     vector >=0.11
   if flag(linear-types)
     hs-source-dirs: src/linear-types

--- a/jvm/src/common/Language/Java/Internal.hs
+++ b/jvm/src/common/Language/Java/Internal.hs
@@ -18,6 +18,7 @@ module Language.Java.Internal
   , getClass
   , setGetClassFunction
   -- * Template Haskell
+  , maxVariadicArgs
   , mkVariadic
   ) where
 
@@ -161,6 +162,10 @@ getStaticFieldAsJValue retsing cname fname = do
     SVoid -> fail "getStaticField cannot yield an object of type void"
     _ -> JObject <$> getStaticObjectField klass field
 
+-- | The maximum supported number of arguments to variadic functions.
+maxVariadicArgs :: Int
+maxVariadicArgs = 32
+
 -- | Generate variadic function type class instances.
 mkVariadic
   :: -- Return type
@@ -168,7 +173,7 @@ mkVariadic
      -- context, action type, argument patterns, argument type singletons, arguments
   -> (TH.TypeQ -> TH.TypeQ -> [TH.PatQ] -> TH.ExpQ -> TH.ExpQ -> TH.DecsQ)
   -> TH.DecsQ
-mkVariadic retty k = fmap concat $ for [0..32] $ \n -> do
+mkVariadic retty k = fmap concat $ for [0..maxVariadicArgs] $ \n -> do
     let -- Coercible type class and Ty associated type defined in downstream module.
         coercible = TH.conT (TH.mkName "Coercible")
         coercibleTy = TH.conT (TH.mkName "Ty")

--- a/jvm/src/common/Language/Java/Internal.hs
+++ b/jvm/src/common/Language/Java/Internal.hs
@@ -161,8 +161,14 @@ getStaticFieldAsJValue retsing cname fname = do
     SVoid -> fail "getStaticField cannot yield an object of type void"
     _ -> JObject <$> getStaticObjectField klass field
 
-mkVariadic :: TH.TypeQ -> (TH.TypeQ -> TH.TypeQ -> [TH.PatQ] -> TH.ExpQ -> TH.ExpQ -> TH.DecsQ) -> TH.DecsQ
-mkVariadic retty k = fmap concat $ for [0..32 :: Int] $ \n -> do
+-- | Generate variadic function type class instances.
+mkVariadic
+  :: -- Return type
+     TH.TypeQ
+     -- context, action type, argument patterns, argument type singletons, arguments
+  -> (TH.TypeQ -> TH.TypeQ -> [TH.PatQ] -> TH.ExpQ -> TH.ExpQ -> TH.DecsQ)
+  -> TH.DecsQ
+mkVariadic retty k = fmap concat $ for [0..32] $ \n -> do
     let -- Coercible type class and Ty associated type defined in downstream module.
         coercible = TH.conT (TH.mkName "Coercible")
         coercibleTy = TH.conT (TH.mkName "Ty")

--- a/jvm/src/common/Language/Java/Unsafe.hs
+++ b/jvm/src/common/Language/Java/Unsafe.hs
@@ -358,7 +358,7 @@ instance VariadicIO_ (IO a) where
 type instance ReturnTypeIO (a -> f) = ReturnTypeIO f
 
 instance (Coercible a, VariadicIO_ f) => VariadicIO_ (a -> f) where
-  sings _ = SomeSing (sing @(Ty a)) : sings @f Proxy
+  sings _ = SomeSing (sing :: Sing (Ty a)) : sings @f Proxy
   apply f x = apply (\xs -> f (coerce x : xs))
 
 -- All errors of the form "Could not deduce (VariadicIO_ x) from ..."
@@ -465,7 +465,7 @@ call
 call obj mname = apply $ \args ->
     unsafeUncoerce <$>
     callToJValue
-      (sing @(Ty b))
+      (sing :: Sing (Ty b))
       (Coerce.coerce obj :: J ty)
       mname
       (sings @f Proxy)
@@ -486,7 +486,8 @@ callStatic
   -> f
 {-# INLINE callStatic #-}
 callStatic cname mname = apply $ \args ->
-   unsafeUncoerce <$> callStaticToJValue (sing @ty) cname mname (sings @f Proxy) args
+   unsafeUncoerce <$>
+     callStaticToJValue (sing :: Sing ty) cname mname (sings @f Proxy) args
 
 -- | Get a static field.
 getStaticField

--- a/jvm/src/common/Language/Java/Unsafe.hs
+++ b/jvm/src/common/Language/Java/Unsafe.hs
@@ -304,13 +304,11 @@ classOf
   -> JNI.String
 classOf x = JNI.fromChars (symbolVal (Proxy :: Proxy sym)) `const` coerce x
 
--- | @VariadicIO_ f@ states that @f@ is a function producing an IO
--- computation with all arguments having instances of 'Coercible'.
--- That is,
+-- | @VariadicIO_ f@ constraints @f@ to be of the form
 --
 -- > f :: a₁ -> ... -> aₙ -> IO b
 --
--- where the context has instances
+-- for any value of @n@, where the context provides
 --
 -- > (Coercible a₁, ... , Coercible aₙ)
 --
@@ -337,13 +335,11 @@ type family ReturnTypeIO f :: *
 
 -- | Document that a function is variadic
 --
--- @VariadicIO f b@ constraints @f@ to be of the form:
+-- @VariadicIO f b@ constraints @f@ to be of the form
 --
 -- > a₁ -> ... -> aₙ -> IO b
 --
--- for any value of @n@,
---
--- where the context has instances
+-- for any value of @n@, where the context provides
 --
 -- > (Coercible a₁, ... , Coercible aₙ)
 --

--- a/jvm/tests/Language/JavaSpec.hs
+++ b/jvm/tests/Language/JavaSpec.hs
@@ -19,12 +19,12 @@ spec = do
     describe "callStatic" $ do
       it "can call double-returning static functions" $ do
         jstr <- reflect ("1.2345" :: Text)
-        callStatic "java.lang.Double" "parseDouble" [coerce jstr]
+        callStatic "java.lang.Double" "parseDouble" jstr
           `shouldReturn` (1.2345 :: Double)
 
       it "can call int-returning static functions" $ do
         jstr <- reflect ("12345" :: Text)
-        callStatic "java.lang.Integer" "parseInt" [coerce jstr]
+        callStatic "java.lang.Integer" "parseInt" jstr
           `shouldReturn` (12345 :: Int32)
 
       it "can call String-returning static functions" $ do
@@ -32,7 +32,8 @@ spec = do
           callStatic
             "java.lang.Integer"
             "toString"
-            [coerce (12345 :: Int32)]
+
+            (12345 :: Int32)
         reify jstr `shouldReturn` ("12345" :: Text)
 
       it "can get static fields" $ do
@@ -42,31 +43,31 @@ spec = do
       it "can get enum values" $ do
         monday :: J ('Class "java.time.DayOfWeek") <-
           getStaticField "java.time.DayOfWeek" "MONDAY"
-        call monday "getValue" []
+        call monday "getValue"
           `shouldReturn` (1 :: Int32)
 
       it "short doesn't under- or overflow" $ do
         maxshort <- reflect (Text.pack (show (maxBound :: Int16)))
         minshort <- reflect (Text.pack (show (minBound :: Int16)))
-        callStatic "java.lang.Short" "parseShort" [coerce maxshort]
+        callStatic "java.lang.Short" "parseShort" maxshort
           `shouldReturn` (maxBound :: Int16)
-        callStatic "java.lang.Short" "parseShort" [coerce minshort]
+        callStatic "java.lang.Short" "parseShort" minshort
           `shouldReturn` (minBound :: Int16)
 
       it "int doesn't under- or overflow" $ do
         maxint <- reflect (Text.pack (show (maxBound :: Int32)))
         minint <- reflect (Text.pack (show (minBound :: Int32)))
-        callStatic "java.lang.Integer" "parseInt" [coerce maxint]
+        callStatic "java.lang.Integer" "parseInt" maxint
           `shouldReturn` (maxBound :: Int32)
-        callStatic "java.lang.Integer" "parseInt" [coerce minint]
+        callStatic "java.lang.Integer" "parseInt" minint
           `shouldReturn` (minBound :: Int32)
 
       it "long doesn't under- or overflow" $ do
         maxlong <- reflect (Text.pack (show (maxBound :: Int64)))
         minlong <- reflect (Text.pack (show (minBound :: Int64)))
-        callStatic "java.lang.Long" "parseLong" [coerce maxlong]
+        callStatic "java.lang.Long" "parseLong" maxlong
           `shouldReturn` (maxBound :: Int64)
-        callStatic "java.lang.Long" "parseLong" [coerce minlong]
+        callStatic "java.lang.Long" "parseLong" minlong
           `shouldReturn` (minBound :: Int64)
 
     describe "newArray" $ do
@@ -86,5 +87,5 @@ spec = do
       -- Applications need extra conversions if the following doesn't hold.
       it "can get Integer when Long is expected" $ do
         let i = maxBound :: Int32
-        j <- new [coerce i] :: IO (J ('Class "java.lang.Integer"))
+        j <- new i :: IO (J ('Class "java.lang.Integer"))
         reify (unsafeCast j) `shouldReturn` (fromIntegral i :: Int64)

--- a/src/common/Language/Java/Inline/Internal.hs
+++ b/src/common/Language/Java/Inline/Internal.hs
@@ -58,6 +58,7 @@ import Data.List (isPrefixOf, intercalate, isSuffixOf, nub)
 import Data.String (fromString)
 import Foreign.JNI (defineClass)
 import Language.Java
+import Language.Java.Internal (maxVariadicArgs)
 import Language.Java.Inline.Internal.Magic as Magic
 import qualified Language.Java.Lexer as Java
 import Language.Haskell.TH.Quote
@@ -187,7 +188,7 @@ blockQQ config input = do
           thnames = map TH.mkName vnames
           thnames' = map TH.mkName (map ('_':) vnames)
       -- Keep consistent with number of instances generated Language.Java.Internal.
-      when (length vnames > 32) $
+      when (length vnames > maxVariadicArgs) $
         TH.reportError "Blocks with more than 32 antiquotation variables not supported."
 
       -- Return a call to the static method we just generated.

--- a/src/common/Language/Java/Inline/Internal.hs
+++ b/src/common/Language/Java/Inline/Internal.hs
@@ -156,11 +156,9 @@ data QQConfig = QQConfig
   { -- | This is the name of the function to use to indicate to the
     -- plugin the presence of a java quasiquotation.
     qqMarker :: TH.Name
-    -- | This is the name of the function to use to invoke the Java stub.
-  , qqCallStatic :: TH.Name
-    -- | This is the name of the function to use for coercing the values of
-    -- antiquotations to `JValues`.
-  , qqCoerce :: TH.Name
+    -- | This produces the call invoke the Java stub.
+    -- It takes the list of arguments that should be passed to the call.
+  , qqCallStatic :: [TH.ExpQ] -> TH.ExpQ
     -- | This is given as argument the invocation of the Java stub, and
     -- is expected to prepend it with code that ensures that the stub is
     -- previously loaded in the JVM.
@@ -199,11 +197,10 @@ blockQQ config input = do
              $(return $ foldr (\a b -> TH.TupE [TH.VarE a, b]) (TH.TupE []) thnames)
              Proxy
              (\ $(return $ foldr (\a b -> TH.TupP [TH.VarP a, b]) (TH.TupP []) thnames') ->
-                $(TH.appsE
-                    ([ TH.varE (qqCallStatic config)
-                     , [| fromString $(TH.stringE ("io.tweag.inlinejava." ++ mangle thismod)) |]
+                $(qqCallStatic config $
+                     [ [| fromString $(TH.stringE ("io.tweag.inlinejava." ++ mangle thismod)) |]
                      , [| fromString $(TH.stringE mname) |]
-                     ] ++ map TH.varE thnames')
+                     ] ++ map TH.varE thnames'
                  )
              )
              |]

--- a/src/common/Language/Java/Inline/Unsafe.hs
+++ b/src/common/Language/Java/Inline/Unsafe.hs
@@ -56,6 +56,7 @@ module Language.Java.Inline.Unsafe
   , loadJavaWrappers
   ) where
 
+import qualified Language.Haskell.TH as TH
 import Language.Haskell.TH.Quote
 import Language.Java
 import Language.Java.Inline.Internal
@@ -84,7 +85,6 @@ import qualified Language.Java.Inline.Internal.QQMarker as QQMarker
 java :: QuasiQuoter
 java = javaWithConfig QQConfig
     { qqMarker = 'QQMarker.qqMarker
-    , qqCallStatic = 'callStatic
-    , qqCoerce = 'coerce
+    , qqCallStatic = \qargs -> TH.appsE $ TH.varE 'callStatic : qargs
     , qqWrapMarker = \qExp -> [| loadJavaWrappers >> $qExp |]
     }


### PR DESCRIPTION
**This PR is mutually exclusive with #133.**

`call` previously took a list of `JValue`'s. Using the dictionaries
embedded in each element, it could construct a `MethodID`. However, this
`MethodID` was not cached as well as one would hope, say when multiple
calls are made to the same method at the same argument types but
different values. Another problem was that all arguments to the method
had to be packed into a list and coerced into a `JValue` before being
passed to the method. This was syntactic overhead. The solution is to
make `call`, `new` and `callStatic` variadic, using the same GADT
solution as for variadic `printf`.

We now pass an extra spec argument to `call`. Like the format string in
`printf`, this argument determines how many more arguments need to be
passed to `call`. Example:

```haskell
call obj "frobnicate" With3Args x y z
```

We no longer need to coerce `x`, `y`, `z`, nor pack them into a list.
Furthermore, this solution leads to decent error messages if arguments
are missing.