### PR TITLE
Move Stack and Bazel linux jobs to buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,12 @@
+steps:
+  - label: "Run tests (Bazel)"
+    command: |
+      . /var/lib/buildkite-agent/.nix-profile/etc/profile.d/nix.sh
+      echo "build --host_platform=@rules_haskell//haskell/platforms:linux_x86_64_nixpkgs" > .bazelrc.local
+      nix-shell --pure --run 'bazel build //...'
+    timeout: 30
+  - label: "Run tests (Stack)"
+    command: |
+      . /var/lib/buildkite-agent/.nix-profile/etc/profile.d/nix.sh
+      nix-shell --pure --run 'stack --nix build --pedantic --test --bench --no-run-benchmarks'
+    timeout: 30

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,57 +1,5 @@
 version: 2
 jobs:
-  build-linux-nix:
-    docker:
-      - image: nixos/nix
-    working_directory: ~/inline-java
-    steps:
-      - checkout
-      - run:
-          name: Install Stack
-          command: |
-            apk update --no-progress && apk --no-progress add ca-certificates bash
-            nix-env -f nixpkgs.nix -iA stack
-      - run:
-          name: Compute cache key
-          command: |
-              (echo shell.nix; echo nixpkgs.nix; find . -name "*.cabal" -o -name "stack.yaml" -type f) | sort | xargs cat > /tmp/stack-deps
-      - restore_cache:
-          keys:
-            - inline-java-stack-dependencies-{{ arch }}-{{ checksum "/tmp/stack-deps" }}-{{ checksum "nixpkgs.nix" }}
-      - run:
-          name: Build dependencies
-          command: |
-            stack --no-terminal --nix build --only-snapshot --prefetch --test --bench -j2
-      - save_cache:
-          key: inline-java-stack-dependencies-{{ arch }}-{{ checksum "/tmp/stack-deps" }}-{{ checksum "nixpkgs.nix" }}
-          paths:
-            - ~/.stack
-      - run:
-          name: Build project
-          command: stack --nix --no-terminal build -j2 --pedantic --test --bench --no-run-tests --no-run-benchmarks
-      - run:
-          name: Test
-          command: stack --nix --no-terminal test
-
-  build-bazel:
-    docker:
-      - image: nixos/nix
-    working_directory: ~/inline-java
-    steps:
-      - checkout
-      - run:
-          name: Install system dependencies
-          command: |
-            apk update --no-progress && apk --no-progress add ca-certificates bash binutils zip
-            nix-env -f nixpkgs.nix -iA gcc bazel stack nix openjdk11 ghc python3
-      - run:
-          name: Build project
-          command: |
-            echo "common --host_platform=@rules_haskell//haskell/platforms:linux_x86_64_nixpkgs" > .bazelrc.local
-            # Build in two steps to avoid OOM.
-            bazel build --jobs 2 @stackage//:singletons
-            bazel build --jobs 2 //...
-
   build-darwin-brew:
     macos:
       xcode: "9.0"
@@ -140,7 +88,5 @@ workflows:
   version: 2
   build:
     jobs:
-      - build-linux-nix
-      - build-bazel
       - build-linux-linear
       - build-darwin-brew

--- a/shell-stack.nix
+++ b/shell-stack.nix
@@ -1,0 +1,27 @@
+{ pkgs ?  import ./nixpkgs.nix {}
+, ghc ? pkgs.haskell.compiler.ghc822
+}:
+
+with pkgs;
+
+let
+  openjdk = openjdk8;
+  jvmlibdir =
+    if stdenv.isLinux
+    then "${openjdk}/lib/openjdk/jre/lib/amd64/server"
+    else "${openjdk}/jre/lib/server";
+  # XXX Workaround https://ghc.haskell.org/trac/ghc/ticket/11042.
+  libHack = if stdenv.isDarwin then {
+      DYLD_LIBRARY_PATH = [jvmlibdir];
+    } else {
+      LD_LIBRARY_PATH = [jvmlibdir];
+    };
+in
+haskell.lib.buildStackProject ({
+  name = "inline-java";
+  buildInputs = [ git openjdk gradle ];
+  ghc = ghc;
+  # XXX Workaround https://ghc.haskell.org/trac/ghc/ticket/11042.
+  extraArgs = ["--extra-lib-dirs=${jvmlibdir}"];
+  LANG = "en_US.utf8";
+} // libHack)

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,7 +11,7 @@ packages:
 - examples/classpath
 
 nix:
-  shell-file: shell.nix
+  shell-file: shell-stack.nix
   path: ["nixpkgs=./nixpkgs.nix"]
 
 docker:


### PR DESCRIPTION
Getting the cache key to be adequately conservative in CircleCI is a
nightmare. And even with caching, reinstalling all dependencies +
restorting the cache takes so much time that an identity build takes 10
minutes or more. The solution is to use BuildKite, like rules_haskell
and rules_sh already do. This won't work (yet) for macOS. But for the
Linux jobs this should speed things up quite significantly, while also
making the CI job definitions simpler.