### PR TITLE
jvm: Implement variadic arguments in the safe interface.

### DIFF
--- a/jvm/jvm.cabal
+++ b/jvm/jvm.cabal
@@ -44,7 +44,8 @@ library
     exposed-modules:
       Language.Java.Safe
     build-depends:
-      linear-base ==0.1.0.0
+      linear-base ==0.1.0.0,
+      ghc-prim
   else
     build-depends:
       singletons >=2.5


### PR DESCRIPTION
The design is complicated w.r.t. the unsafe interface because the linear interface uses an abstract monad supplying an instance of MonadIO.

There is firstly the challenge to pick the right instance when types in the context are not fully instantiated. And secondly, there are more situations where implementation details could
leak in error messages, and more custom error messages need to be provided.

Closes #137.