### PR TITLE
Use UnsafeUnrestrictedReference to mark unrestricted references in the safe interface

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,24 +1,20 @@
 steps:
   - label: "Run tests (Bazel)"
     command: |
-      . /var/lib/buildkite-agent/.nix-profile/etc/profile.d/nix.sh
       echo "build --host_platform=@rules_haskell//haskell/platforms:linux_x86_64_nixpkgs" > .bazelrc.local
       nix-shell --pure --run 'bazel build //...'
     timeout: 30
   - label: "Run tests (Stack)"
     command: |
-      . /var/lib/buildkite-agent/.nix-profile/etc/profile.d/nix.sh
       nix-shell --pure --run 'stack --nix build --pedantic --test --bench --no-run-benchmarks'
     timeout: 30
   - label: "Install linear-types enabled GHC"
     command: |
-      . /var/lib/buildkite-agent/.nix-profile/etc/profile.d/nix.sh
       nix-shell shell-linear-types.nix --command ''
     timeout: 120
     key: "install-linear-ghc"
   - label: "Run tests (linear-types + Stack)"
     command: |
-      . /var/lib/buildkite-agent/.nix-profile/etc/profile.d/nix.sh
       nix-shell --pure --run 'stack --nix --stack-yaml stack-linear.yaml build --pedantic --test jni jvm inline-java'
     timeout: 60
     depends_on: "install-linear-ghc"

--- a/benchmarks/wizzardo-http/src/main/haskell/Language/Java/Function.hs
+++ b/benchmarks/wizzardo-http/src/main/haskell/Language/Java/Function.hs
@@ -196,7 +196,7 @@ createCallback f registerNativesForCallback createJFunction =
     let Linear.Builder{..} = Linear.monadBuilder in do
     Unrestricted longFunctionPtr <- Linear.liftIOU (createStablePtrHandle f)
     jFunction <- createJFunction longFunctionPtr
-    (jFunction, Unrestricted klass) <- getObjectClass jFunction
+    (jFunction, UnsafeUnrestrictedReference klass) <- getObjectClass jFunction
     Linear.liftIO (registerNativesForCallback klass)
     Linear.liftIO (JNI.deleteLocalRef klass)
     return jFunction

--- a/benchmarks/wizzardo-http/src/main/haskell/Main.hs
+++ b/benchmarks/wizzardo-http/src/main/haskell/Main.hs
@@ -20,7 +20,7 @@ import DbHandler (createDbHandler)
 import Foreign.JNI.Safe (newGlobalRef_, withJVM, withLocalFrame_)
 import qualified Language.Haskell.TH.Syntax as TH
 import Language.Java.Inline.Safe
-import Language.Java.Safe (reflect)
+import Language.Java.Safe (UnsafeUnrestrictedReference(..), reflect)
 import System.Environment (getArgs, lookupEnv)
 import qualified System.IO.Linear as Linear
 import Wizzardo.Http.Handler (JHandler, createHandler)
@@ -93,9 +93,9 @@ createPlainTextHandler :: MonadIO m => m JHandler
 createPlainTextHandler =
     let Linear.Builder{..} = Linear.monadBuilder in do
     jmsg <- reflect (ByteString.Char8.pack "Hello, World!")
-    Unrestricted jGlobalMsg <- newGlobalRef_ jmsg
+    UnsafeUnrestrictedReference jGlobalMsg <- newGlobalRef_ jmsg
     createHandler $ \_req resp -> Linear.withLinearIO $ do
-      let ujmsg = Unrestricted jGlobalMsg
+      let ujmsg = UnsafeUnrestrictedReference jGlobalMsg
       [java| { $resp
                .setBody($ujmsg)
                .appendHeader(Header.KV_CONTENT_TYPE_TEXT_PLAIN);

--- a/benchmarks/wizzardo-http/src/main/haskell/Wizzardo/Http/Handler.hs
+++ b/benchmarks/wizzardo-http/src/main/haskell/Wizzardo/Http/Handler.hs
@@ -26,7 +26,6 @@ import Language.Java.Function (createBiFunction)
 import Language.Java.Inline.Safe
 import Language.Java.Safe
 import Prelude
-import Prelude.Linear (Unrestricted(..))
 
 imports "com.wizzardo.http.*"
 imports "com.wizzardo.http.request.*"
@@ -40,14 +39,17 @@ type Request = 'Class "com.wizzardo.http.request.Request"
 
 createHandler
   :: Linear.MonadIO m
-  => (Unrestricted JRequest -> Unrestricted JResponse -> IO ())
+  => (  UnsafeUnrestrictedReference JRequest
+     -> UnsafeUnrestrictedReference JResponse
+     -> IO ()
+     )
   -> m JHandler
 createHandler handle =
     let Linear.Builder{..} = Linear.monadBuilder in do
     f <- createBiFunction $ \req resp ->
       handle
-        (Unrestricted req)
-        (Unrestricted resp)
+        (UnsafeUnrestrictedReference req)
+        (UnsafeUnrestrictedReference resp)
       Control.Monad.>>
         Control.Monad.return resp
     [java| new Handler() {

--- a/examples/directory-server/src/Directory/Server.hs
+++ b/examples/directory-server/src/Directory/Server.hs
@@ -41,7 +41,7 @@ server port =
     let Linear.Builder{..} = Linear.monadBuilder in do
     Unrestricted mvStop <- Linear.liftIOU newEmptyMVar
     Unrestricted env <- liftU ask
-    Unrestricted httpServer <-
+    UnsafeUnrestrictedReference httpServer <-
       startHttpServer (fromIntegral port) (runHandler env)
     lift
       (logInfoN $ Text.pack $

--- a/examples/directory-server/src/Directory/Server/Http.hs
+++ b/examples/directory-server/src/Directory/Server/Http.hs
@@ -52,7 +52,7 @@ startHttpServer
   :: Linear.MonadIO m
   => Int32
   -> (JHttpExchange -> IO ())
-  -> m (Unrestricted JHttpServer)
+  -> m (UnsafeUnrestrictedReference JHttpServer)
 startHttpServer port handler =
     let Linear.Builder{..} = Linear.monadBuilder in do
     jHandler <- createHandler handler
@@ -115,7 +115,7 @@ createHandler handle =
           @Override
           public void finalize() { hsFinalize($longTablePtr); }
         } |]
-    (jHandler2, Unrestricted klass) <- getObjectClass jHandler
+    (jHandler2, UnsafeUnrestrictedReference klass) <- getObjectClass jHandler
     Linear.liftIO (registerNativesForHttpHandler klass)
     Linear.liftIO (JNI.deleteLocalRef klass)
     return jHandler2

--- a/jni/src/linear-types/Foreign/JNI/Safe.hs
+++ b/jni/src/linear-types/Foreign/JNI/Safe.hs
@@ -100,8 +100,11 @@ throwNew :: MonadIO m => JNI.JClass -> JNI.String ->. m ()
 throwNew jclass = Unsafe.toLinear $ \msg ->
     liftIO (JNI.throwNew jclass msg)
 
-findClass :: MonadIO m => ReferenceTypeName -> m (Unrestricted JNI.JClass)
-findClass name = liftIO (Unrestricted <$> JNI.findClass name)
+findClass
+  :: MonadIO m
+  => ReferenceTypeName
+  -> m (UnsafeUnrestrictedReference JNI.JClass)
+findClass name = liftIO (UnsafeUnrestrictedReference <$> JNI.findClass name)
 
 newObject
   :: MonadIO m
@@ -252,21 +255,24 @@ getStaticMethodID
 getStaticMethodID jclass = Unsafe.toLinear2 $ \methodname sig ->
   liftIOU (JNI.getStaticMethodID jclass methodname sig)
 
-getObjectClass :: MonadIO m => J ty ->. m (J ty, Unrestricted JNI.JClass)
+getObjectClass
+  :: MonadIO m => J ty ->. m (J ty, UnsafeUnrestrictedReference JNI.JClass)
 getObjectClass = Unsafe.toLinear $ \o ->
-    liftIO ((,) o . Unrestricted <$> JNI.getObjectClass (unJ o))
+    liftIO ((,) o . UnsafeUnrestrictedReference <$> JNI.getObjectClass (unJ o))
 
 -- | Creates a global reference to the object referred to by
 -- the given reference.
 --
 -- Arranges for a finalizer to call 'deleteGlobalRef' when the
 -- global reference is no longer reachable on the Haskell side.
-newGlobalRef :: MonadIO m => J ty ->. m (J ty, Unrestricted (JNI.J ty))
+newGlobalRef
+  :: MonadIO m => J ty ->. m (J ty, UnsafeUnrestrictedReference (JNI.J ty))
 newGlobalRef = Unsafe.toLinear $ \o -> liftIO
-    ((,) o . Unrestricted <$> JNI.newGlobalRef (unJ o))
+    ((,) o . UnsafeUnrestrictedReference <$> JNI.newGlobalRef (unJ o))
 
 -- | Like 'newGlobalRef' but it deletes the input instead of returning it.
-newGlobalRef_ :: MonadIO m => J ty ->. m (Unrestricted (JNI.J ty))
+newGlobalRef_
+  :: MonadIO m => J ty ->. m (UnsafeUnrestrictedReference (JNI.J ty))
 newGlobalRef_ j =
     newGlobalRef j Linear.>>= \(j1, g) -> g Linear.<$ deleteLocalRef j1
 
@@ -277,9 +283,11 @@ deleteGlobalRef o = liftIO (JNI.deleteGlobalRef o)
 -- the reference when it is not longer reachable. Use
 -- 'deleteGlobalRefNonFinalized' to destroy this reference.
 newGlobalRefNonFinalized
-  :: MonadIO m => J ty ->. m (J ty, Unrestricted (JNI.J ty))
+  :: MonadIO m => J ty ->. m (J ty, UnsafeUnrestrictedReference (JNI.J ty))
 newGlobalRefNonFinalized = Unsafe.toLinear $ \o ->
-    liftIO ((,) o . Unrestricted <$> JNI.newGlobalRefNonFinalized (unJ o))
+    liftIO ((,) o . UnsafeUnrestrictedReference <$>
+             JNI.newGlobalRefNonFinalized (unJ o)
+           )
 
 -- | Like 'deleteGlobalRef' but it can be used only on references created with
 -- 'newGlobalRefNonFinalized'.

--- a/jni/src/linear-types/Foreign/JNI/Types/Safe.hs
+++ b/jni/src/linear-types/Foreign/JNI/Types/Safe.hs
@@ -2,6 +2,7 @@
 
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
@@ -83,6 +84,14 @@ toJNIJValues :: [JValue] -> [JNI.JValue]
 toJNIJValues = map $ \case
     JValue jvalue -> jvalue
     JObject (J j) -> JNI.JObject j
+
+-- | A type to wrap unrestricted references
+--
+-- Unlike with linear references, the programmer is reponsible
+-- for ensuring that the unrestricted references are destroyed
+-- in timely fashion.
+data UnsafeUnrestrictedReference a where
+  UnsafeUnrestrictedReference :: a -> UnsafeUnrestrictedReference a
 
 type JObject = J ('Class "java.lang.Object")
 type JString = J ('Class "java.lang.String")


### PR DESCRIPTION
At a suggestion of @hanshoglund, I'm forbidding safe quasiquotations from manipulating unrestricted references of type `Unrestricted (J ty)`. Instead, the user must use the isomorphic type `UnsafeUnrestrictedReference (J ty)`.

This is more verbose, but it is very explicit in that the programmer forgoes the correctness guarantees of the safe interface for those references.