### PR TITLE
change: bound the queue of background workers (closes #154)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -103,6 +103,7 @@ stack_snapshot(
         "ghc-prim",
         "ordered-containers",
         "semigroups",
+        "stm",
         "syb",
         "th-abstraction",
         "th-lift",

--- a/jni/BUILD.bazel
+++ b/jni/BUILD.bazel
@@ -16,6 +16,7 @@ haskell_library(
         "@stackage//:constraints",
         "@stackage//:deepseq",
         "@stackage//:inline-c",
+        "@stackage//:stm",
         "@stackage//:singletons",
     ],
     visibility = ["//visibility:public"],

--- a/jni/jni.cabal
+++ b/jni/jni.cabal
@@ -51,7 +51,8 @@ library
     containers >=0.5,
     constraints >=0.8,
     deepseq >=1.4.2,
-    inline-c >=0.6
+    inline-c >=0.6,
+    stm >= 2.3
   if flag(linear-types)
     hs-source-dirs: src/linear-types
     build-depends:

--- a/jni/src/common/Foreign/JNI/Internal/BackgroundWorker.hs
+++ b/jni/src/common/Foreign/JNI/Internal/BackgroundWorker.hs
@@ -48,7 +48,7 @@ create runInInitializedThread = do
         (_, tasks) -> tasks <$ writeTVar nextBatch emptyBatch
 
 defaultQueueSize :: Int
-defaultQueueSize = 1024
+defaultQueueSize = 1024 * 1024
 
 -- | Set the maximum number of pending tasks
 setQueueSize :: BackgroundWorker -> Int -> IO ()

--- a/jni/src/common/Foreign/JNI/Internal/BackgroundWorker.hs
+++ b/jni/src/common/Foreign/JNI/Internal/BackgroundWorker.hs
@@ -53,7 +53,10 @@ defaultQueueSize = 1024 * 1024
 
 -- | Set the maximum number of pending tasks
 setQueueSize :: BackgroundWorker -> Int -> IO ()
-setQueueSize = writeIORef . queueSizeRef
+setQueueSize (BackgroundWorker {queueSizeRef}) n =
+  if n > 0
+  then writeIORef queueSizeRef n
+  else return ()
 
 data StopWorkerException = StopWorkerException
   deriving Show

--- a/jni/src/common/Foreign/JNI/Internal/BackgroundWorker.hs
+++ b/jni/src/common/Foreign/JNI/Internal/BackgroundWorker.hs
@@ -55,7 +55,7 @@ setQueueSize :: BackgroundWorker -> Int -> IO ()
 setQueueSize (BackgroundWorker {queueSizeRef}) n =
   if n > 0
   then atomically $ writeTVar queueSizeRef n
-  else return ()
+  else error ("The queue size must be a positive number. Tried " ++ show n)
 
 data StopWorkerException = StopWorkerException
   deriving Show


### PR DESCRIPTION
This is a preliminary implementation of an upper bound
on the number of tasks that can be left pending for a
BackgroundWorker to execute.

This strategy is based on busy-waiting, which should be avoided.