### PR TITLE
add: verbose Exception on getMethodID failure

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@ steps:
   - label: "Run tests (Bazel)"
     command: |
       echo "build --host_platform=@rules_haskell//haskell/platforms:linux_x86_64_nixpkgs" > .bazelrc.local
-      nix-shell --pure --run 'bazel test //...'
+      nix-shell --pure --run 'bazel test --test_output=all //...'
     timeout: 30
   - label: "Run tests (Stack)"
     command: |

--- a/jni/src/common/Foreign/JNI/Internal.hs
+++ b/jni/src/common/Foreign/JNI/Internal.hs
@@ -1,5 +1,9 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Foreign.JNI.Internal where
 
+import Data.Text (Text)
+import qualified Data.Text as Text
 import qualified Foreign.JNI.String as JNI
 
 -- | A reference type name is not just any 'JNI.String', but a fully qualified
@@ -23,3 +27,42 @@ newtype MethodSignature = MethodSignature JNI.String
 
 instance Show MethodSignature where
   show (MethodSignature str) = show str
+
+jniMethodToJavaSignature :: Text -> Either String ([Text], Text)
+jniMethodToJavaSignature sig = do
+    (argTypes, rest1) <- dropChar '(' sig >>= many toJavaType
+    (returnType, rest2) <- dropChar ')' rest1 >>= toJavaType
+    if Text.null rest2 then return (argTypes, returnType)
+    else Left $ "Unexpected suffix " ++ show rest2
+  where
+    dropChar c t = case Text.uncons t of
+      Just (c', t') | c == c' -> Right t'
+      _ -> Left $ unwords
+              [ "Expected ", show c, "but found", show t]
+    many p = go id
+      where
+        go acc t = case p t of
+          Left _ -> Right (acc [], t)
+          Right (x, t') -> go (acc . (x:)) t'
+    toJavaType t = case Text.uncons t of
+      Just (c, t') ->
+        case c of
+          'L' -> case Text.breakOn ";" t' of
+            (jtype, rest) -> Right (Text.map substSlash jtype, Text.drop 1 rest)
+          '[' ->
+            fmap (\(jtype, rest) -> (jtype <> "[]", rest)) (toJavaType t')
+          'Z' -> Right ("boolean", t')
+          'B' -> Right ("byte", t')
+          'C' -> Right ("char", t')
+          'S' -> Right ("short", t')
+          'I' -> Right ("int", t')
+          'J' -> Right ("long", t')
+          'F' -> Right ("float", t')
+          'D' -> Right ("double", t')
+          'V' -> Right ("void", t')
+          _ -> Left $ "Unexpected char " ++ show c ++ " at " ++ show t'
+      Nothing ->
+        Left "Unexpected empty text"
+    substSlash = \case
+      '/' -> '.'
+      c -> c

--- a/jni/src/common/Foreign/JNI/Unsafe.hs
+++ b/jni/src/common/Foreign/JNI/Unsafe.hs
@@ -65,8 +65,8 @@ instance Show NoSuchMethod where
         [ "No method named", noSuchMethodName exn
         , "has signature", noSuchMethodSignature exn
         , "in class", noSuchMethodClassName exn
-        , ".\nThe candidate methods are:"
-        , Text.unlines sigs
+        , "\nThe candidate methods are:\n"
+        <> Text.unlines sigs
         ]
 
 getMethodID

--- a/jni/src/common/Foreign/JNI/Unsafe.hs
+++ b/jni/src/common/Foreign/JNI/Unsafe.hs
@@ -1,3 +1,9 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
 -- | Low-level bindings to the Java Native Interface (JNI).
 --
 -- Read the
@@ -20,6 +26,74 @@
 -- Reexports definitions from "Foreign.JNI.Unsafe.Internal".
 module Foreign.JNI.Unsafe
   ( module Foreign.JNI.Unsafe.Internal
+  , getMethodID
+  , getStaticMethodID
   ) where
 
-import Foreign.JNI.Unsafe.Internal
+import Control.Exception (Exception, catch, throwIO)
+import Data.List (intercalate)
+import Data.Singletons (sing)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import Foreign.JNI.Types
+import qualified Foreign.JNI.String as JNI
+import qualified Foreign.JNI.Unsafe.Internal as Internal
+import Foreign.JNI.Unsafe.Internal hiding (getMethodID, getStaticMethodID)
+import Foreign.JNI.Unsafe.Internal.Introspection
+
+data NoSuchMethod = NoSuchMethod
+  { className :: Text.Text
+  , methodName :: Text.Text
+  , targetSignature :: String
+  , candidateSignatures :: [Text.Text]
+  } deriving Exception
+
+instance Show NoSuchMethod where
+  show exn =
+    let base = "No method named " ++ show (methodName exn)
+            ++ " with signature " ++ targetSignature exn
+            ++ " was found in class " ++ show (className exn)
+    in
+      base ++ case candidateSignatures exn of
+        [] -> ""
+        sigs -> "\nCandidate type signatures are:\n"
+          ++ (intercalate "\n" $ map show sigs)
+
+-- | wrapper around getMethodID' : raise a verbose exception if no method was found
+getMethodID
+  :: JClass -- ^ A class object as returned by 'findClass'
+  -> JNI.String -- ^ Field name
+  -> MethodSignature -- ^ JNI signature
+  -> IO JMethodID
+getMethodID cls method sig = catch
+  (Internal.getMethodID cls method sig)
+  (handleJVMException cls method sig)
+
+-- | wrapper around getStaticMethodID' : raise a verbose exception if no method was found
+getStaticMethodID
+  :: JClass -- ^ A class object as returned by 'findClass'
+  -> JNI.String -- ^ Field name
+  -> MethodSignature -- ^ JNI signature
+  -> IO JMethodID
+getStaticMethodID cls method sig = catch
+  (Internal.getStaticMethodID cls method sig)
+  (handleJVMException cls method sig)
+
+-- | When the exception is an instance of java.lang.NoSuchMethodError,
+-- throw a verbose exception suggesting possible corrections.
+-- If it isn't, throw it as is.
+handleJVMException
+  :: JClass
+  -> JNI.String
+  -> MethodSignature
+  -> JVMException
+  -> IO a
+handleJVMException cls method sig (JVMException e) = do
+  kexception <- findClass $ referenceTypeName $ sing @('Class "java.lang.NoSuchMethodError")
+  isInstanceOf (upcast e) kexception >>= \case
+    True -> do
+      signatures <- getSignatures cls method
+      clsName <- getClassName cls
+      let methodNameTxt = Text.decodeUtf8 $ JNI.toByteString method
+      throwIO $ NoSuchMethod clsName methodNameTxt (show sig) signatures
+    False -> throwIO $ JVMException e

--- a/jni/src/common/Foreign/JNI/Unsafe.hs
+++ b/jni/src/common/Foreign/JNI/Unsafe.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -27,6 +28,7 @@
 -- Reexports definitions from "Foreign.JNI.Unsafe.Internal".
 module Foreign.JNI.Unsafe
   ( module Foreign.JNI.Unsafe.Internal
+  , NoSuchMethod(..)
   , getMethodID
   , getStaticMethodID
   ) where
@@ -36,33 +38,36 @@ import Data.Singletons (sing)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Foreign.JNI.Types
+import Foreign.JNI.Internal (MethodSignature(..))
 import qualified Foreign.JNI.String as JNI
 import qualified Foreign.JNI.Unsafe.Internal as Internal
 import Foreign.JNI.Unsafe.Internal hiding (getMethodID, getStaticMethodID)
 import Foreign.JNI.Unsafe.Internal.Introspection
 import System.IO.Unsafe (unsafePerformIO)
 
+-- | Throws when a method can't be found
 data NoSuchMethod = NoSuchMethod
-  { className :: Text.Text
-  , methodName :: Text.Text
-  , targetSignature :: Text.Text
-  , candidateSignatures :: [Text.Text]
+  { noSuchMethodClassName :: Text.Text
+  , noSuchMethodName ::  Text.Text
+  , noSuchMethodSignature :: Text.Text
+  , noSuchMethodCandidates :: [Text.Text]
   } deriving Exception
 
 instance Show NoSuchMethod where
-  show exn = Text.unpack $ Text.unwords $ case candidateSignatures exn of
-    [] ->
-      [ "No method named", methodName exn
-      , "was found in class", className exn
-      , ".\nWas there a mispelling ?"
-      ]
-    sigs ->
-      [ "No method named", methodName exn
-      , "has signature", targetSignature exn
-      , "in class", className exn
-      , ".\nCandidates methods are:"
-      , Text.unlines sigs
-      ]
+  show exn = Text.unpack $ Text.unwords $
+    case noSuchMethodCandidates exn of
+      [] ->
+        [ "No method named", noSuchMethodName exn
+        , "was found in class", noSuchMethodClassName exn
+        , ".\nWas there a mispelling ?"
+        ]
+      sigs ->
+        [ "No method named", noSuchMethodName exn
+        , "has signature", noSuchMethodSignature exn
+        , "in class", noSuchMethodClassName exn
+        , ".\nThe candidate methods are:"
+        , Text.unlines sigs
+        ]
 
 getMethodID
   :: JClass -- ^ A class object as returned by 'findClass'
@@ -99,11 +104,15 @@ handleJVMException
   -> MethodSignature
   -> JVMException
   -> IO a
-handleJVMException cls method sig (JVMException e) =
+handleJVMException cls method (MethodSignature sig) (JVMException e) =
   isInstanceOf (upcast e) kexception >>= \case
     True -> do
-      signatures <- getSignatures cls method
-      clsName <- getClassName cls
-      let methodNameTxt = Text.decodeUtf8 $ JNI.toByteString method
-      throwIO $ NoSuchMethod clsName methodNameTxt (Text.pack $ show sig) signatures
+      noSuchMethodCandidates <- getSignatures cls method
+      noSuchMethodClassName <- getClassName cls
+      throwIO $ NoSuchMethod
+        { noSuchMethodClassName
+        , noSuchMethodName = Text.decodeUtf8 (JNI.toByteString method)
+        , noSuchMethodSignature = Text.decodeUtf8 (JNI.toByteString sig)
+        , noSuchMethodCandidates
+        }
     False -> throwIO $ JVMException e

--- a/jni/tests/Foreign/JNISpec.hs
+++ b/jni/tests/Foreign/JNISpec.hs
@@ -6,7 +6,9 @@
 module Foreign.JNISpec where
 
 import Control.Concurrent (runInBoundThread)
+import Control.Exception (try)
 import Data.Singletons
+import Foreign.JNI.String (fromChars)
 import Foreign.JNI.Types
 import Foreign.JNI.Unsafe
 import Foreign.JNI.Unsafe.Internal.Introspection
@@ -26,7 +28,7 @@ spec = do
           findClass (referenceTypeName (sing :: Sing ('Class "java.lang.Long")))
             `shouldThrow` \ThreadNotAttached -> True
 
-    around_ (runInBoundThread . runInAttachedThread) $
+    around_ (runInBoundThread . runInAttachedThread) $ do
       describe "isInstanceOf" $ do
         it "identifies a class name as a String" $ do
           klong <- findClass (referenceTypeName (sing :: Sing ('Class "java.lang.Long")))
@@ -42,3 +44,16 @@ spec = do
           klong <- findClass (referenceTypeName (sing :: Sing ('Class "java.lang.Long")))
           name <- callObjectMethod klong classGetNameMethod []
           isInstanceOf name klong `shouldReturn` False
+
+      describe "getMethodID" $ do
+        it "gives correct hints on a mistake" $ do
+          kstring <- findClass (referenceTypeName (sing :: Sing ('Class "java.lang.String")))
+          let sig = methodSignature [] (sing @('Class "java.lang.String"))
+          result <- try $ getMethodID kstring (fromChars "replace") sig
+          case result of
+            Left (NoSuchMethod _ _ _ candidates) ->
+              candidates `shouldBe`
+                [ "public java.lang.String java.lang.String.replace(char,char)"
+                , "public java.lang.String java.lang.String.replace(java.lang.CharSequence,java.lang.CharSequence)"
+                ]
+            _ -> expectationFailure "call should have failed with a NoSuchMethod exception"

--- a/jni/tests/Foreign/JNISpec.hs
+++ b/jni/tests/Foreign/JNISpec.hs
@@ -7,6 +7,7 @@ module Foreign.JNISpec where
 
 import Control.Concurrent (runInBoundThread)
 import Control.Exception (try)
+import Data.List (sort)
 import Data.Singletons
 import Foreign.JNI.Internal (jniMethodToJavaSignature)
 import Foreign.JNI.String (fromChars)
@@ -53,7 +54,7 @@ spec = do
           result <- try $ getMethodID kstring (fromChars "replace") sig
           case result of
             Left e -> do
-              noSuchMethodOverloadings e `shouldBe`
+              sort (noSuchMethodOverloadings e) `shouldBe`
                 [ "public java.lang.String java.lang.String.replace(char,char)"
                 , "public java.lang.String java.lang.String.replace(java.lang.CharSequence,java.lang.CharSequence)"
                 ]


### PR DESCRIPTION
We wrap getMethodID and getStaticMethodID from Foreign.JNI.Unsafe.Internal into a function
that produces a more verbose and more helpful exception when it fails.

Solves #148