### PR TITLE
wip: print Throwable stack traces

### DIFF
--- a/jni/CHANGELOG.md
+++ b/jni/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 * Failed lookups with getMethodID and getStaticMethodID now
   list the overloadings of the method that was searched (#164).
 
+* Exceptions raised in the JVM do not automatically print a line in stdin.
+  Instead, a Haskell function is provided to print the stack trace of any
+  JVMException (#168).
+
 ## [0.7.0] - 2020-07-16
 
 ### Added

--- a/jni/CHANGELOG.md
+++ b/jni/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 * Failed lookups with getMethodID and getStaticMethodID now
   list the overloadings of the method that was searched (#164).
 
-* Exceptions raised in the JVM do not automatically print a line in stdin.
+* Exceptions raised in the JVM do not automatically print a line in stderr.
   Instead, a Haskell function is provided to print the stack trace of any
   JVMException (#168).
 

--- a/jni/src/common/Foreign/JNI/Unsafe/Internal.hs
+++ b/jni/src/common/Foreign/JNI/Unsafe/Internal.hs
@@ -234,9 +234,11 @@ $(C.verbatim "static __thread JNIEnv* jniEnv; ")
 -- | A JNI call may cause a (Java) exception to be raised. This module raises it
 -- as a Haskell exception wrapping the Java exception.
 newtype JVMException = JVMException JThrowable
-  deriving Show
 
 instance Exception JVMException
+
+instance Show JVMException where
+  show (JVMException e) = show e ++ ": Call (Foreign.JNI.showException e) to see details."
 
 -- | Thrown when @Get<PrimitiveType>ArrayElements@ returns a null pointer,
 -- because it wanted to copy the array contents but couldn't. In this case the

--- a/jni/src/common/Foreign/JNI/Unsafe/Internal.hs
+++ b/jni/src/common/Foreign/JNI/Unsafe/Internal.hs
@@ -274,7 +274,6 @@ throwIfException :: Ptr JNIEnv -> IO a -> IO a
 throwIfException env m = m `finally` do
     excptr <- [CU.exp| jthrowable { (*$(JNIEnv *env))->ExceptionOccurred($(JNIEnv *env)) } |]
     unless (excptr == nullPtr) $ do
-      [CU.exp| void { (*$(JNIEnv *env))->ExceptionDescribe($(JNIEnv *env)) } |]
       [CU.exp| void { (*$(JNIEnv *env))->ExceptionClear($(JNIEnv *env)) } |]
       throwIO . JVMException =<< newGlobalRef =<< objectFromPtr excptr
 

--- a/jni/src/common/Foreign/JNI/Unsafe/Internal/Introspection.hs
+++ b/jni/src/common/Foreign/JNI/Unsafe/Internal/Introspection.hs
@@ -8,6 +8,7 @@ module Foreign.JNI.Unsafe.Internal.Introspection
  , getSignatures
  , toText
  , classGetNameMethod
+ , showException
  ) where
 
 import Control.Exception (bracket)
@@ -108,3 +109,68 @@ getClassName :: JClass -> IO Text.Text
 getClassName c = withDeleteLocalRef
     (unsafeCast <$> callObjectMethod c classGetNameMethod []) $
     \(jName :: JString) -> toText jName
+
+-- | The "Throwable" interface.
+iThrowable :: JClass
+{-# NOINLINE iThrowable #-}
+iThrowable = unsafePerformIO $ withDeleteLocalRef
+  (findClass $ referenceTypeName $ sing @('Class "java.lang.Throwable"))
+  newGlobalRef
+
+-- | Throwable.printStackTrace(PrintWriter s)
+throwablePrintStackTraceMethod :: JMethodID
+{-# NOINLINE throwablePrintStackTraceMethod #-}
+throwablePrintStackTraceMethod = unsafePerformIO $
+  getMethodID iThrowable (JNI.fromChars "printStackTrace") $
+    methodSignature [SomeSing (sing :: Sing ('Class "java.io.PrintWriter"))] (sing :: Sing 'Void)
+
+-- | The "StringWriter" class.
+kStringWriter :: JClass
+{-# NOINLINE kStringWriter #-}
+kStringWriter = unsafePerformIO $ withDeleteLocalRef
+  (findClass $ referenceTypeName $ sing @('Class "java.io.StringWriter"))
+  newGlobalRef
+
+-- | The "PrintWriter" class.
+kPrintWriter :: JClass
+{-# NOINLINE kPrintWriter #-}
+kPrintWriter = unsafePerformIO $ withDeleteLocalRef
+  (findClass $ referenceTypeName $ sing @('Class "java.io.PrintWriter"))
+  newGlobalRef
+
+-- | StringWriter.toString
+stringWriterToStringMethod :: JMethodID
+{-# NOINLINE stringWriterToStringMethod #-}
+stringWriterToStringMethod = unsafePerformIO $
+  getMethodID kStringWriter (JNI.fromChars "toString") $
+    methodSignature [] (sing @('Class "java.lang.String"))
+
+-- | Equivalent Java code:
+-- StringWriter stringWriter = new StringWriter();
+-- PrintWriter printWriter = new PrintWriter(stringWriter);
+-- e.printStackTrace(printWriter);
+-- return stringWriter.toString();
+showException :: JVMException -> IO Text.Text
+showException (JVMException e) = withDeleteLocalRef
+  (newObject
+    kStringWriter
+    (methodSignature [] (sing :: Sing 'Void))
+    [])
+  $ \stringWriter -> withDeleteLocalRef
+    (newObject
+      kPrintWriter
+      (methodSignature
+        [SomeSing (sing :: Sing ('Class "java.io.StringWriter"))]
+        (sing :: Sing 'Void))
+      [JObject stringWriter])
+    $ \printWriter -> do
+      _ <- callVoidMethod
+        e
+        throwablePrintStackTraceMethod
+        [JObject printWriter]
+      withDeleteLocalRef
+        (unsafeCast <$> callObjectMethod
+          stringWriter
+          stringWriterToStringMethod
+          [])
+        toText

--- a/jni/src/common/Foreign/JNI/Unsafe/Internal/Introspection.hs
+++ b/jni/src/common/Foreign/JNI/Unsafe/Internal/Introspection.hs
@@ -160,7 +160,7 @@ showException (JVMException e) = withDeleteLocalRef
     (newObject
       kPrintWriter
       (methodSignature
-        [SomeSing (sing :: Sing ('Class "java.io.StringWriter"))]
+        [SomeSing (sing :: Sing ('Class "java.io.Writer"))]
         (sing :: Sing 'Void))
       [JObject stringWriter])
     $ \printWriter -> do


### PR DESCRIPTION
Solves #166 

This PR adds a function `showException :: JVMException -> IO Text` which provides the stack trace of the underlying `JThrowable`.
This function may be used in a custom `instance Show JVMException` instead of the default one. Once `JVMException` has a proper `Show` instance, we will be able to remove the call to `ExceptionDescribe` in `Foreign.JNI.Unsafe.Internal.throwIfException`, which is the goal of #166