### PR TITLE
Made safe deleteLocalRef and newLocalRef use Coercible for more generality

### DIFF
--- a/tests/Language/Java/Inline/SafeSpec.hs
+++ b/tests/Language/Java/Inline/SafeSpec.hs
@@ -17,6 +17,7 @@ import qualified Control.Functor.Linear as Linear
 import Data.Int
 import Foreign.JNI (JVMException)
 import Foreign.JNI.Safe
+import qualified Foreign.JNI.Types (J(..))
 import Language.Java.Safe
 import Language.Java.Inline.Safe
 import Prelude hiding ((>>=), (>>))


### PR DESCRIPTION
I made the type signatures of the two above-mentioned functions more general, by allowing any type coercible to a `J ty` to be copied or deleted, as is the case in the unsafe version. Note that in most cases, one will now need to import `Foreign.JNI.Types` and `Foreign.JNI.Types.Safe` in order to use these functions, so that the compiler can derive the appropriate `Coercible` instances.