### PR TITLE
Two bug fixes in `call`

### DIFF
--- a/jvm/src/linear-types/Language/Java/Safe.hs
+++ b/jvm/src/linear-types/Language/Java/Safe.hs
@@ -363,12 +363,13 @@ call = Unsafe.toLinear $ \obj mname -> apply $ Unsafe.toLinear $ \args -> do
       fromJNIJValue <$>
         Java.callToJValue
           @ty1
-          (sing @ty1)
+          (sing @(Ty b))
           (Coerce.coerce obj)
           mname
           (sings @f Proxy)
           (toJNIJValues args)
         Prelude.<* deleteLinearJObjects args
+    <* deleteLocalRef obj
 
 strictUnsafeUncoerce :: Coercible a => IO JValue -> IO a
 strictUnsafeUncoerce m = m Prelude.>>= \x -> evaluate (unsafeUncoerce x)


### PR DESCRIPTION
This commit fixes the bug where the safe `call` didn't delete the calling object despite linear multiplicity. Also, it fixes the bug with the return type singleton passed to `callToValue`.