### PR TITLE
Android compatibility

### DIFF
--- a/jni/jni.cabal
+++ b/jni/jni.cabal
@@ -1,5 +1,5 @@
 name:                jni
-version:             0.8.0
+version:             0.9.0
 synopsis:            Complete JNI raw bindings.
 description:         Please see README.md.
 homepage:            https://github.com/tweag/inline-java/tree/master/jni#readme
@@ -18,9 +18,15 @@ source-repository head
   location: https://github.com/tweag/inline-java
   subdir: jni
 
+Flag android
+  Description:   Turn on JNI Android compatibility
+  Default:       False
+
 library
   hs-source-dirs: src/common src/linear-types
   cc-options: -std=c11
+  if flag(android)
+    cpp-options: -DANDROID
   extra-libraries: jvm
   exposed-modules:
     Foreign.JNI

--- a/jni/src/linear-types/Foreign/JNI/Safe.hs
+++ b/jni/src/linear-types/Foreign/JNI/Safe.hs
@@ -67,7 +67,9 @@
 
 module Foreign.JNI.Safe
   ( module Foreign.JNI.Safe
+#if !defined(ANDROID)
   , JNI.withJVM
+#endif
   ) where
 
 import Control.Exception hiding (throw)

--- a/jvm/jvm.cabal
+++ b/jvm/jvm.cabal
@@ -1,5 +1,5 @@
 name:                jvm
-version:             0.6.0
+version:             0.7.0
 synopsis:            Call JVM methods from Haskell.
 description:         Please see README.md.
 homepage:            http://github.com/tweag/inline-java/tree/master/jvm#readme
@@ -18,8 +18,14 @@ source-repository head
   location: https://github.com/tweag/inline-java
   subdir: jvm
 
+flag android
+  Description:   Turn on JNI Android compatibility
+  Default:       False
+
 library
   hs-source-dirs: src/common src/linear-types
+  if flag(android)
+    cpp-options: -DANDROID
   exposed-modules:
     Language.Java
     Language.Java.Internal

--- a/jvm/src/common/Language/Java/Unsafe.hs
+++ b/jvm/src/common/Language/Java/Unsafe.hs
@@ -40,6 +40,7 @@
 -- class and method lookups, for performance. This memoization is safe only when
 -- no new named classes are defined at runtime.
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
@@ -69,7 +70,9 @@
 module Language.Java.Unsafe
   ( module Foreign.JNI.Types
   -- * JVM instance management
+#if !defined(ANDROID)
   , withJVM
+#endif
   -- * JVM calls
   , classOf
   , getClass

--- a/jvm/src/linear-types/Language/Java/Safe.hs
+++ b/jvm/src/linear-types/Language/Java/Safe.hs
@@ -37,6 +37,7 @@
 -- class and method lookups, for performance. This memoization is safe only when
 -- no new named classes are defined at runtime.
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
@@ -62,7 +63,9 @@
 module Language.Java.Safe
   ( module Foreign.JNI.Types.Safe
   -- * JVM instance management
+#if !defined(ANDROID)
   , withJVM
+#endif
   -- * JVM calls
   , classOf
   , new


### PR DESCRIPTION
attempt at an Android compatibility PR.

exposes GetJavaVM (as `getEnvJVM`), also add `getEnvVersion` while we're at it, adds `setJVM`, exposes `jvm`.

VM management functions were not moved to a `Foreign.JNI.JVM` module as this would involve moving the `jniEnv`/`jniJVM` variables that all the code in `Foreign.JNI.Unsafe.Internal` depends on. I like the idea of tidying up the clutter of that module by moving a few thing somewhere else but it's not clear where to make the cut as to avoid too much interdependency.

note while `jvm` is exposed I'm not too sure what purpose that serves, also its return type is `Ptr JVM` as opposed to other JVM related functions that return `IO JVM`. maybe it needs a wrapper `getJVM` that makes it `IO` but then again I don't understand the purpose of exposing it in the first place.

there is an `android` compiler flag now that eliminates some of the VM management functions that are not Android compatible. note that an Android app can use the regular, non-Android version of the lib just fine as long as it diligently calls `setJVM` and refrains from calling the "illegal" functions.

there is a small demo Android app here https://github.com/user16332/demo-android/tree/tweag that shows usage of the lib. it uses a version hacked somewhat to work with the `flake.nix` provided, such as including C header files and older versions of singletons-base and linear-base to work with GHC 9.6.3.